### PR TITLE
Update README with all current experiment projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 A directory of experimentation projects built with Anthropic's new Claude models (Fable 5 / Mythos).
 
+Each project folder is self-contained and includes the originating prompt as `prompt.txt`, preserved verbatim alongside the code.
+
 ## Projects
 
-| Project | Description |
-|---------|-------------|
-| [navigable 3D scene](./navigable%203D%20scene/) | A navigable 3D scene of Sidi Bou Said in a single HTML file |
+| Project | Description | Stack |
+|---------|-------------|-------|
+| [jack-3d-portfolio](./jack-3d-portfolio/) | Dark-themed 3D creator portfolio landing page for "Jack" with gradient hero text | React, TypeScript, Vite, Tailwind CSS, Framer Motion |
+| [prisma landing](./prisma%20landing/) | Cinematic landing page for the creative studio "PRISMA" — dark, moody, warm cream palette | React, TypeScript, Vite, Tailwind CSS, Framer Motion |
+| [sidi-bou-said-3d-walk](./sidi-bou-said-3d-walk/) | Navigable, fully procedural 3D walk through Sidi Bou Said, Tunisia in a single HTML file | Three.js, single-file HTML/JS |
+| [vanguard hero landing](./vanguard%20hero%20landing/) | Fullscreen hero landing page for the creative agency "VANGUARD" with a looping background video | React, TypeScript, Vite, Tailwind CSS |


### PR DESCRIPTION
## Summary
- Replace the stale single-project table (it pointed at a removed `navigable 3D scene` folder) with all four current experiments: jack-3d-portfolio, prisma landing, sidi-bou-said-3d-walk, and vanguard hero landing
- Add a stack column (verified against each project's `package.json`/config) and a note that every project folder preserves its originating prompt as `prompt.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)