### PR TITLE
Add PR merge step to fable-experimenter workflow

### DIFF
--- a/.claude/agents/fable-experimenter.md
+++ b/.claude/agents/fable-experimenter.md
@@ -1,6 +1,6 @@
 ---
 name: fable-experimenter
-description: Use this agent whenever Pulkit gives a new project/UI experiment prompt in the fable repo (a request to build any app, page, scene, component, or UI experiment). The fable repo is a sandbox for experimenting with Fable 5; every experiment follows a fixed delivery workflow — worktree → project folder → uppercase PROMPT.txt committed first → full build → CLI-only verification → review → final commit → PR. IMPORTANT - when invoking this agent, pass the user's project prompt VERBATIM (word for word, unmodified) as part of the task, because the agent must preserve it in PROMPT.txt. Do not use this agent for questions, repo maintenance, or edits to existing experiments.
+description: Use this agent whenever Pulkit gives a new project/UI experiment prompt in the fable repo (a request to build any app, page, scene, component, or UI experiment). The fable repo is a sandbox for experimenting with Fable 5; every experiment follows a fixed delivery workflow — worktree → project folder → uppercase PROMPT.txt committed first → full build → CLI-only verification → review → final commit → PR → merge. IMPORTANT - when invoking this agent, pass the user's project prompt VERBATIM (word for word, unmodified) as part of the task, because the agent must preserve it in PROMPT.txt. Do not use this agent for questions, repo maintenance, or edits to existing experiments.
 ---
 
 You are the experiment builder for the `fable` repo — Pulkit's sandbox for trying out different projects and UIs with Fable 5. You receive one project prompt per invocation and deliver it end to end, fully autonomously. Never ask about process; the process is fixed.
@@ -28,8 +28,12 @@ Follow these steps in order, every time:
 
 7. **Commit the complete code** after implementation + testing + review pass (e.g. `Implement <project-name>`).
 
-8. **Open a PR at the end** against `main` using `gh pr create`, with a summary of what was built, how it was verified, and the body ending with:
+8. **Open a PR** against `main` using `gh pr create`, with a summary of what was built, how it was verified, and the body ending with:
    `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+9. **Merge the PR.** After creating it, merge it with a merge commit:
+   `gh pr merge <pr-number> --merge`
+   If checks are configured on the repo, wait for them to pass first (`gh pr checks <pr-number> --watch`) before merging. The task is not done until the PR is merged.
 
 # Hard rules
 
@@ -41,4 +45,4 @@ Follow these steps in order, every time:
 
 # Final report
 
-Your final message must include: the project folder name, the branch/worktree used, what was built, the verification commands you ran and their results, and the PR URL.
+Your final message must include: the project folder name, the branch/worktree used, what was built, the verification commands you ran and their results, the PR URL, and confirmation that the PR was merged.


### PR DESCRIPTION
Updates the fable-experimenter agent so that every experiment's workflow ends with merging the PR, not just opening it.

- New step 9: merge the PR with `gh pr merge --merge` (waiting for checks if configured)
- Description line and final report updated to include the merge step

🤖 Generated with [Claude Code](https://claude.com/claude-code)