### PR TITLE
docs: credit designprompts.dev in README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A directory of experimental landing pages, hero sections, and interactive prototypes generated with Claude Fable 5.
 
-Most project folders are self-contained and include the originating prompt as `prompt.md`, preserved alongside the generated code. Some prompts were inspired by or adapted from public prompt/design references, including [cnemri's gist](https://gist.github.com/cnemri/c917e11b3a6936823b509dcff53392aa), [motionsites.ai](https://motionsites.ai/), and [lafys.com](https://lafys.com/).
+Most project folders are self-contained and include the originating prompt as `prompt.md`, preserved alongside the generated code. Some prompts were inspired by or adapted from public prompt/design references, including [cnemri's gist](https://gist.github.com/cnemri/c917e11b3a6936823b509dcff53392aa), [motionsites.ai](https://motionsites.ai/), [lafys.com](https://lafys.com/), and [designprompts.dev](https://www.designprompts.dev/).
 
 The code in this repository was generated on my side with Claude Fable 5. This whole repo is vibe coded, so use it with precautions: review the code, check dependencies, verify accessibility/responsiveness, and run the local project checks before using anything in production.
 


### PR DESCRIPTION
Adds [designprompts.dev](https://www.designprompts.dev/) to the list of public prompt/design references credited in the root README.

## Change
- Append `designprompts.dev` to the existing references list alongside cnemri's gist, motionsites.ai, and lafys.com.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpK4ZrbhuKKgNJ48Qz3rNB)_