### PR TITLE
Fix UI Desgin experiment count (9 → 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>UI Desgin (9)</b></summary>
+<summary><b>UI Desgin (10)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/ui-desgin/README.md
+++ b/ui-desgin/README.md
@@ -1,6 +1,6 @@
 # UI Desgin
 
-9 **UI Desgin** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+10 **UI Desgin** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
## What

Corrects the **UI Desgin** category count from `9` to `10` in both:
- root `README.md` — `<b>UI Desgin (10)</b>`
- `ui-desgin/README.md` — `10 **UI Desgin** experiments…`

## Why

PRs #118 (`copy-machine-landing-exact-spec`) and #121 (`copy-machine-setup`) were developed concurrently. Each added one UI Desgin experiment and bumped the category count `8 → 9` against the same base. When both merged into `main`, the two new rows were preserved (now **10** experiment rows), but the count line — identical in both branches — merged without conflict and stuck at **9**.

Result on `main`: 10 actual rows vs. a declared count of 9 in both READMEs. This change brings the declared counts back in line with the actual rows (verified: 10 = 10 in each file). No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5HtCzmwVqMymMjBnHew2a)_