### PR TITLE
ci: run Cloudinary demo upload on every push to main

### DIFF
--- a/.github/workflows/upload-video-demos.yml
+++ b/.github/workflows/upload-video-demos.yml
@@ -1,6 +1,8 @@
 name: Upload Video Demos to Cloudinary
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Adds a `push` trigger on `main` so the Cloudinary video-demo upload runs automatically on every push, alongside the existing manual `workflow_dispatch`.

On push, the workflow `inputs.*` are empty (falsey), so it takes the default "upload new only" path — no dry run, no force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)