### PR TITLE
Make demo recorder's Chromium configurable via env vars

### DIFF
--- a/scripts/record-demos/record.mjs
+++ b/scripts/record-demos/record.mjs
@@ -334,7 +334,15 @@ function encode(inputArgs) {
 
 async function main() {
 	fs.mkdirSync(path.dirname(OUT), { recursive: true });
-	const browser = await chromium.launch({ headless: true });
+	// Allow a locally-provided Chromium + extra launch args via env (used in sandboxed
+	// environments where Playwright's bundled browser can't be downloaded). When unset,
+	// this is identical to the original `chromium.launch({ headless: true })`.
+	const launchOpts = { headless: true };
+	if (process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE)
+		launchOpts.executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+	if (process.env.PLAYWRIGHT_LAUNCH_ARGS)
+		launchOpts.args = process.env.PLAYWRIGHT_LAUNCH_ARGS.split(" ").filter(Boolean);
+	const browser = await chromium.launch(launchOpts);
 
 	// Warm-up + measure (no recording). The reload absorbs Vite's first-load
 	// dependency-optimization full reload so it never lands in the recording.


### PR DESCRIPTION
## What this is

A small, **fully backward-compatible** tweak to `scripts/record-demos/record.mjs`: it now honors two optional env vars when launching Playwright's Chromium —

- `PLAYWRIGHT_CHROMIUM_EXECUTABLE` → sets `executablePath`
- `PLAYWRIGHT_LAUNCH_ARGS` → sets `args` (space-separated)

When both are unset, behavior is **identical** to the previous `chromium.launch({ headless: true })`.

## Why

This is the workaround needed to record demos in sandboxed environments where Playwright's bundled Chromium can't be downloaded (e.g. Claude Code on the web, where `cdn.playwright.dev` isn't allowlisted). It lets the recorder point at a locally-provided Chrome-for-Testing build instead.

## Provenance / context

This change surfaced as a leftover edit in the working tree during the `horizon-strata-shader` experiment (#208, now merged). That experiment deliberately kept recorder-infra edits **out** of its deliverable PR, so this generalized, env-var-based version is offered separately here.

**This PR is optional** — it's an infra quality-of-life improvement, not a requested feature. Close it if you'd rather not carry the env-var hooks in the shared recorder script. Left as a **draft** for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWSgBNW6Lcry1DAtRaRDrd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWSgBNW6Lcry1DAtRaRDrd)_