### PR TITLE
docs: reconcile README counts to disk (Shaders 64, Projects 175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (173)
+## Projects (175)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -192,7 +192,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Shaders (63)</b></summary>
+<summary><b>Shaders (64)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -1,6 +1,6 @@
 # Shaders
 
-63 **Shaders** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+64 **Shaders** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
Concurrent PR merges around #221 left the README counts drifted from the actual folder counts on disk:

- `shaders/` has **64** project folders, but both the root README `<summary>` and `shaders/README.md` intro said **63**.
- The root `## Projects` total said **173** but the real total across all categories is **175**.

This recomputes every count from the actual folder count and sets:
- Shaders intro + root summary → **64**
- Root `## Projects` → **175**

Verified after the fix: every category's `<summary>` (root) and intro count (category README) equals its disk folder count, the sum equals `## Projects (175)`, and all 175 projects have `prompt.md` / `demo.mp4` / `poster.jpg` / a `posters.json` entry with no broken category links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YMQqsiRBrE4st9gHR17cu)_