### PR TITLE
docs: reconcile README counts to disk (Shaders 65, Projects 176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (175)
+## Projects (176)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -192,7 +192,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Shaders (64)</b></summary>
+<summary><b>Shaders (65)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -1,6 +1,6 @@
 # Shaders
 
-64 **Shaders** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+65 **Shaders** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
Follow-up reconciliation: further concurrent shader merges advanced the folder counts again (shaders is now **65** on disk, total **176**) while the READMEs lagged at 64/175.

Recomputed from the actual folder count:
- Shaders intro + root summary → **65**
- Root `## Projects` → **176**

Verified: every category `<summary>` (root) and intro count (category README) equals its disk folder count, and the sum equals `## Projects (176)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YMQqsiRBrE4st9gHR17cu)_