### PR TITLE
Fix count drift + posters.json conflict markers from #238 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (189)
+## Projects (190)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -194,7 +194,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Shaders (76)</b></summary>
+<summary><b>Shaders (77)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/posters.json
+++ b/posters.json
@@ -1035,21 +1035,19 @@
     "height": 800,
     "blurDataURL": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAEAAPAAD//gAQTGF2YzYyLjI4LjEwMQD/2wBDAAgQEBMQExYWFhYWFhoYGhsbGxoaGhobGxsdHR0iIiIdHR0bGx0dICAiIiUmJSMjIiMmJigoKDAwLi44ODpFRVP/xABZAAADAQEAAAAAAAAAAAAAAAAAAQIHAwEBAAAAAAAAAAAAAAAAAAAAABAAAwABBAMBAAAAAAAAAAAAEQEAAgMhUWFxwRJBEQEAAAAAAAAAAAAAAAAAAAAA/8AAEQgAEAAYAwEiAAIRAAMRAP/aAAwDAQACEQMRAD8AwjHTz1C1uO17p+UiStuKVk8Zkk/sHPxBfLlAg//Z"
   },
-<<<<<<< HEAD
-  "shaders/warp-checks-background-lab": {
-    "poster": "shaders/warp-checks-background-lab/poster.jpg",
-    "video": "shaders/warp-checks-background-lab/demo.mp4",
-    "width": 1280,
-    "height": 800,
-    "blurDataURL": "data:image/jpeg;base64,/9j//gAPTGF2YzYxLjMuMTAwAP/bAEMACBAQExATFhYWFhYWGhgaGxsbGhoaGhsbGx0dHSIiIh0dHRsbHR0gICIiJSYlIyMiIyYmKCgoMDAuLjg4OkVFU//EAG4AAQEBAQEAAAAAAAAAAAAAAAUEAwIGAQEBAQAAAAAAAAAAAAAAAAAGAAUQAQABAwMCBwEAAAAAAAAAAAECEQAhgSIDEhShclJBMbHwUREBAAEDAwUBAAAAAAAAAAAAAQIAEhFxQSHh0THwE5H/wAARCAAQABgDASIAAhEAAxEA/9oADAMBAAIRAxEAPwBys44/aX08la4/ut6SXjBQB1+m42eV+cNsLCWXAuHw45o/GP0y2Ahpl93ojuZySKjShmN29fl8L8+UZG33LT2em8kuN5fvWphI4LjRO9f/2Q=="
-=======
   "shaders/volumetric-beams-shader": {
     "poster": "shaders/volumetric-beams-shader/poster.jpg",
     "video": "shaders/volumetric-beams-shader/demo.mp4",
     "width": 1280,
     "height": 800,
     "blurDataURL": "data:image/jpeg;base64,/9j//gAQTGF2YzYwLjMxLjEwMgD/2wBDAAgQEBMQExYWFhYWFhoYGhsbGxoaGhobGxsdHR0iIiIdHR0bGx0dICAiIiUmJSMjIiMmJigoKDAwLi44ODpFRVP/xABkAAACAwEAAAAAAAAAAAAAAAAGBQEEAgcBAQEBAAAAAAAAAAAAAAAAAAMEBhAAAgICAQUBAAAAAAAAAAAAAQIAERIDBFFhoYIUMREAAgMBAQEAAAAAAAAAAAAAAwERAAIhgRL/wAARCAAQABgDASIAAhEAAxEA/9oADAMBAAIRAxEAPwDlHG1q7AM2A60T4EJDw0AsbQfRoEJtxjb7Gxq5rAlGs9dfPz2W/LjeoU0Dff8AIsoSX25StlIiFy9OlN//2Q=="
->>>>>>> 6ce0ccb (Implement volumetric-beams-shader)
+  },
+  "shaders/warp-checks-background-lab": {
+    "poster": "shaders/warp-checks-background-lab/poster.jpg",
+    "video": "shaders/warp-checks-background-lab/demo.mp4",
+    "width": 1280,
+    "height": 800,
+    "blurDataURL": "data:image/jpeg;base64,/9j//gAPTGF2YzYxLjMuMTAwAP/bAEMACBAQExATFhYWFhYWGhgaGxsbGhoaGhsbGx0dHSIiIh0dHRsbHR0gICIiJSYlIyMiIyYmKCgoMDAuLjg4OkVFU//EAG4AAQEBAQEAAAAAAAAAAAAAAAUEAwIGAQEBAQAAAAAAAAAAAAAAAAAGAAUQAQABAwMCBwEAAAAAAAAAAAECEQAhgSIDEhShclJBMbHwUREBAAEDAwUBAAAAAAAAAAAAAQIAEhFxQSHh0THwE5H/wAARCAAQABgDASIAAhEAAxEA/9oADAMBAAIRAxEAPwBys44/aX08la4/ut6SXjBQB1+m42eV+cNsLCWXAuHw45o/GP0y2Ahpl93ojuZySKjShmN29fl8L8+UZG33LT2em8kuN5fvWphI4LjRO9f/2Q=="
   },
   "shaders/warp-dithering-shader": {
     "poster": "shaders/warp-dithering-shader/poster.jpg",

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -1,6 +1,6 @@
 # Shaders
 
-76 **Shaders** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+77 **Shaders** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
## Why

The merge of #238 (volumetric-beams-shader) into `main` landed two repo-wide inconsistencies caused by concurrent merges colliding on the same lines:

1. **README count drift** — after `blue-meshy-shader-lab` and `warp-checks-background-lab` merged alongside, `main` ended up with **77 shader folders** but the count lines still read **Shaders (76) / Projects (189)**.
2. **Broken `posters.json`** — the manifest was committed with unresolved git conflict markers (`<<<<<<<`/`=======`/`>>>>>>>`), making it **invalid JSON**.

## What this fixes

- Reconciles every count to the actual folder count: **Shaders 77**, **Projects 190**; every category `<summary>` equals its block row count, and each category README intro matches.
- Resolves the `posters.json` conflict so it parses again — valid JSON with **190 entries**, keeping `volumetric-beams-shader`, `warp-checks-background-lab`, and `blue-meshy-shader-lab` in alphabetical order.

## Verified
- `python3 -c "import json; json.load(open('posters.json'))"` → valid, 190 entries.
- Full audit: all 8 categories reconcile (folders = intro = rows), total 190 = `Projects (190)`, demos 190 = manifest 190, no remaining git conflict markers in any tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01THL2jKjwr7XLyKTEeZgfXr)_