### PR TITLE
Reconcile root project total to disk (197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (196)
+## Projects (197)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 


### PR DESCRIPTION
Consistency sweep follow-up. The root README's per-category summaries and every category README intro already match the actual folder counts on disk (which total **197**), but the \`## Projects\` grand total had drifted to **196** — a one-off lost increment from a concurrent sibling merge whose category bump did not propagate to the total.

This sets the total to **197** to match disk. No project files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)