### PR TITLE
Reconcile template/project counts from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (224)
+## Projects (225)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -293,7 +293,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Templates (20)</b></summary>
+<summary><b>Templates (21)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-20 **Templates** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+21 **Templates** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
Consistency-sweep fix after the synapse-design-system merge (#278). Concurrent PR merges collapsed the count lines to 224 projects / 20 templates; actual disk counts are **225 projects** and **21 templates**. Every template folder already had table rows in both READMEs — only the three count numbers were stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVpNHMrPNh1rM2nuBAkaKW)_