### PR TITLE
Reconcile Templates counts in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (232)
+## Projects (235)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -293,7 +293,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Templates (28)</b></summary>
+<summary><b>Templates (31)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-28 **Templates** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+31 **Templates** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
## Reconcile Templates counts

The three-way merge of #290 combined concurrently-added Templates rows with summary integers from my conflict resolution, leaving the count numbers out of sync with the actual tables on `main`. The tables themselves were correct (31 Templates rows, 235 total rows), but the summary integers still read the pre-concurrent-merge values.

This fixes the three drifted numbers to match disk:
- Root **`## Projects (232)` → `(235)`** (sum of all category counts now equals 235, matching 235 `prompt.md` dirs on disk).
- Root **`<summary><b>Templates (28)</b>` → `(31)`**.
- `templates/README.md` intro **`28 Templates experiments` → `31`**.

### Verification
- Root header `235` == sum of the nine category summaries `235` == `find -name prompt.md` count `235`.
- Templates summary `31` == `templates/README.md` intro `31` == Templates table rows `31` == template dirs on disk `31`.
- No other category drifted; only the Templates count and the total moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WroyejUfJXDnoS3xqtY87M)_