### PR TITLE
Reconcile project counts to disk (248 total / 44 templates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (245)
+## Projects (248)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -293,7 +293,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Templates (41)</b></summary>
+<summary><b>Templates (44)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-41 **Templates** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
+44 **Templates** experiments generated with Claude Fable 5 — part of the [claude-directory](../README.md).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
## Summary

Consistency sweep follow-up to #281. Concurrent template PRs left the root README `## Projects` count and the Templates `<summary>`/intro counts behind the real folder counts.

Recomputed from disk:
- `## Projects (245)` -> `## Projects (248)`
- Templates `<summary>` `(41)` -> `(44)`
- `templates/README.md` intro `41` -> `44`

Verified: 44 template folders on disk, 248 total folders across all categories, every template folder has a matching row in both READMEs, and `posters.json` has all 248 entries with no missing demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LVVa4ZnVARSQTZzjw6BF8)_