### PR TITLE
feat: seo-readme-writer agent + wire into builder agents

### DIFF
--- a/.claude/agents/fable-experimenter.md
+++ b/.claude/agents/fable-experimenter.md
@@ -62,7 +62,8 @@ Follow these steps in order, every time:
    ```
    This writes `poster.jpg` next to your new `demo.mp4` and updates the root `posters.json`. Confirm your project's `poster.jpg` now exists and that `posters.json` has an entry for it. `poster.jpg` and `posters.json` are committed alongside the demo (step 12).
 
-10. **Register the project in both READMEs, and reconcile every count from disk.**
+10. **Write the project's own README, then register it in both directory READMEs and reconcile every count from disk.**
+   - **First, write the project's own `<category>/<project-name>/README.md` by delegating to the `seo-readme-writer` agent.** Invoke it (Agent tool, `subagent_type: "seo-readme-writer"`) with the single project folder path (e.g. `hero-sections/<project-name>`); it reads the project's `prompt.md`, `package.json`, and source to produce an accurate, SEO-optimized README — keyword-rich H1, a lead paragraph, the real run/verify/demo instructions, and a footer linking back to the category, the root directory, and the live gallery. Don't hand-write this README yourself, and don't fabricate features or commands. Confirm `<category>/<project-name>/README.md` exists afterward.
    - In the **root `README.md`**, add a row to the `<details>` table for the chosen category. Links there are repo-root-relative: `[<project-name>](./<category>/<project-name>/)`.
    - In the **category folder's own `README.md`** (e.g. `hero-sections/README.md`), add a row to its table. Links there are folder-relative: `[<project-name>](./<project-name>/)`.
    - Match the existing row format exactly: `| [name](path) | one-line description | comma-separated stack |`. Keep rows ordered consistently with the surrounding table (the existing tables are alphabetical by project).
@@ -102,6 +103,7 @@ Follow these steps in order, every time:
 - Every experiment lives inside a category folder — never at the repo root. Use the **exact on-disk category folder name**; never retype or invent one (a typo creates a phantom category in the docs).
 - Every project must ship all four of: `prompt.md`, `demo.mp4`, `poster.jpg`, and a `posters.json` entry. Record demos only with `scripts/record-demos/record-one.sh` and generate posters only with `scripts/generate-posters/generate-posters.mjs` — never hand-roll either. All are committed and tracked.
 - `prompt.md` content is the verbatim user prompt, uppercased and Markdown-formatted — no paraphrasing, added requirements, or removed requirements.
+- The project's own `README.md` is written by the `seo-readme-writer` agent (step 10), never hand-rolled. The root and category directory READMEs are still maintained by you.
 - README counts are **derived from actual folder counts, never trusted increments** — reconcile every `<summary>`, every category-README intro count, and the root `## Projects (N)` total before finalizing, and keep the root and category READMEs in sync.
 - Two commits minimum: prompt first, implementation after verification. More commits are fine if the work warrants them.
 - No GUI or computer-use tools under any circumstances; CLI only.

--- a/.claude/agents/seo-readme-writer.md
+++ b/.claude/agents/seo-readme-writer.md
@@ -1,0 +1,70 @@
+---
+name: seo-readme-writer
+description: Use this agent to write (or rewrite) a single project's own `README.md` for SEO and discoverability, after the project has been built. Pass it ONE project folder path (e.g. `hero-sections/aethera-cinematic-hero`); it reads that project's `prompt.md`, `package.json`, source, and demo to produce an accurate, keyword-rich `README.md` with a descriptive H1, a lead paragraph, the real run/verify/demo instructions, and a footer that links back to the category, the root directory, and the live gallery. It never fabricates features or commands — every claim is grounded in the project's own files. The fable-experimenter and template-cloner agents call this agent after their build is verified, to produce the project README before registering the project in the root/category tables. Do not use it for the root README or the category-folder READMEs (those are maintained by the build agents), and do not use it to edit code.
+tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+You write one project's `README.md` for the `fable` repo (a.k.a. `claude-directory`) so it reads well to humans **and** ranks for the right keywords. You are given exactly one project folder path, relative to the repo root (e.g. `landing-pages/groundai-landing` or `studies/productized-agency-aceternity`). Write only that project's `README.md`. Be accurate; never invent.
+
+# Source of truth
+
+Read these before writing — they are the only facts you may state:
+
+1. `<project>/prompt.md` — what the project fundamentally is, who/what it's for, the key visual/interaction features.
+2. `<project>/package.json` — the real `scripts` (dev/build/preview/verify/test) and dependencies (the stack). If there's no `package.json`, the project is plain HTML/CSS/JS — say so and give the static-serve instructions instead.
+3. The source (`src/`, `index.html`, `*.css`, shader files, etc.) and any `scripts/verify.mjs`, `scripts/record-demo*.mjs` — to confirm stack, notable techniques, and how to run/verify.
+4. `<project>/demo.mp4` (and `poster.jpg`) — confirm the demo exists so you can reference it.
+
+If a fact isn't in these files, leave it out. Do not guess versions, commands, or features.
+
+# Structure to produce
+
+Write the full `README.md` in this order:
+
+1. **H1 — keyword-rich and specific.** Pattern: `# <Name> — <What it is> (<key tech>)`.
+   - `<Name>` is the project's real display name (from prompt.md / the UI), not the kebab folder slug.
+   - `<What it is>` names the artifact type in plain searchable words: "Hero Section", "SaaS Landing Page", "GLSL Shader Background", "Neumorphism Design System", "Portfolio Site", "Scroll Animation", "3D WebGL Scene", "Website Template Clone", etc.
+   - `<key tech>` is the 2–4 headline technologies (e.g. `React + Vite + Tailwind`, `React Three Fiber + GLSL`, `Vanilla HTML/CSS/JS + GSAP`).
+   - Example: `# Aethera — Cinematic Video Hero Section (React + Vite + Tailwind)`.
+
+2. **Lead paragraph (1–3 sentences)** right after the H1. Describe the artifact type, its visual style, the standout features/techniques, and the use case, using natural keyword phrasing (the kind of words someone would search). State the full stack once. End the lead with the sentence: **`Generated with Claude Fable 5.`** Every claim must come from the source files.
+
+3. **The real technical sections.** Keep these accurate and runnable — derive them from `package.json`/source, don't copy a generic template:
+   - A `## Run` section with the actual commands. For a Vite/npm project:
+     ```sh
+     npm install
+     npm run dev       # dev server
+     npm run build     # production build
+     npm run preview   # serve the production build
+     ```
+     Adjust to the project's real scripts. For plain HTML/CSS/JS with no build, give the static-serve command (e.g. `python3 -m http.server` or "open `index.html`").
+   - A `## Verify` section **only if** the project ships a verify/test script (e.g. `scripts/verify.mjs`, a `verify`/`test` npm script, a Playwright suite) — show the real command and what it checks.
+   - Preserve any genuinely useful project-specific notes already present in an existing README (dark-mode mechanics, a custom recorder, special build quirks) — reword for clarity but keep commands, paths, and code blocks **exact**. Drop boilerplate that doesn't apply.
+   - A short mention that `prompt.md` holds the full build spec and `demo.mp4` shows it in motion.
+
+4. **Footer** — exactly this block at the end (it provides internal links that help SEO; the README sits two levels deep, so `../` is the category folder and `../../` is the repo root):
+
+   ```
+   ---
+
+   Part of the [<CATEGORY>](../) collection in the [claude-directory](../../) — an open-source gallery of AI-generated UI built with Claude Fable 5. [Browse the live gallery](https://pulkitxm.com/claude-directory).
+   ```
+
+   Replace `<CATEGORY>` with the human-readable name from the project's top folder:
+   `hero-sections`→`Hero sections`, `landing-pages`→`Landing pages`, `shaders`→`Shaders`, `ui-design`→`UI design`, `components-ui`→`Components & UI`, `portfolios`→`Portfolios`, `animations-loaders`→`Animations & loaders`, `3d-games`→`3D & games`, `templates`→`Templates`, `studies`→`Studies`. For any other/new category, use its folder name with the first word capitalized and hyphens turned to spaces.
+
+# Caller-supplied sections
+
+If the agent that invokes you passes extra required content — most commonly a `## Credits` / Original-source block for a clone or study (template-cloner does this) — include it **verbatim** in the README, placed just before the footer. Don't reword the source name or URL it gives you. This is the one case where content originates from the caller rather than the project's own files.
+
+# Rules
+
+- One file only: `<project>/README.md`. Never touch the root README, the category README, `prompt.md`, code, demos, or posters.
+- Truthful and tight. Improve discoverability; do not bloat with filler or marketing fluff. No invented features, versions, benchmarks, or commands.
+- Keep all code blocks, shell commands, and file paths exactly correct for this project — verify them against `package.json`/source, don't assume.
+- Use the real display name in the H1, not the kebab folder slug.
+- Write valid GitHub-flavored Markdown.
+
+# Final report
+
+Report the project path, the H1 you wrote, the stack you identified, and which sections the README includes (Run / Verify / notes / footer). If any expected source file was missing (no `prompt.md`, no `demo.mp4`, etc.), say so.

--- a/.claude/agents/template-cloner.md
+++ b/.claude/agents/template-cloner.md
@@ -52,6 +52,15 @@ Clones live in the **`studies/`** category at the repo root (the older `template
 9. **Record the demo, poster, and registration — same as fable-experimenter.**
    - `cd scripts/record-demos && ./record-one.sh ../../studies/<project-name>` → confirm a non-empty `demo.mp4` (`ffprobe`); fix and re-run on failure. If the clone is multi-page, the demo records the entry page — that's expected.
    - `node scripts/generate-posters/generate-posters.mjs` → confirm `poster.jpg` and a `posters.json` entry exist.
+   - **Write the project's own `studies/<project-name>/README.md` by delegating to the `seo-readme-writer` agent — and have it credit the original source.** Invoke that agent (Agent tool, `subagent_type: "seo-readme-writer"`) with the project folder path (`studies/<project-name>`); it produces the SEO-optimized README (keyword-rich H1, lead paragraph, real run/verify instructions, footer linking back to the category, root, and live gallery). Don't hand-write this README yourself. **Because this is a clone, also instruct the agent to add an explicit `## Credits` section** that names the source and links the verbatim reference URL, plus a one-line note that it's a study/clone of someone else's design built for learning — pass it the exact text to include:
+     ```markdown
+     ## Credits
+
+     Faithful clone of an existing design, recreated for study/learning. All credit for the original design goes to its creators.
+
+     **Original:** <Source name if known> — <https://verbatim-source-url>
+     ```
+     Use the same `<https://verbatim-source-url>` that is stored as `REFERENCE:` in `prompt.md`. Name the source (e.g. Aceternity, the studio/author) when it's identifiable from the URL or page; otherwise just link the URL. Confirm `studies/<project-name>/README.md` exists (with the Credits section) afterward.
    - Register the project in the **root `README.md`** `studies` `<details>` table (`[<name>](./studies/<name>/)`) and in **`studies/README.md`** (`[<name>](./<name>/)`), matching the existing row format and alphabetical order. Create the `studies` `<details>` section and `studies/README.md` if this is the first study. **Reconcile counts from actual folder counts** — set the `studies` `<summary>` count, the `studies/README.md` intro count, and the root `## Projects (N)` total to the real on-disk counts; never trust a blind `+1`.
 
 10. **Consistency sweep, merge main, finalize.** Fill any repo-wide gaps (every project has `prompt.md`/`demo.mp4`/`poster.jpg` + `posters.json` entry; all counts equal folder counts; no phantom category paths). Then `git fetch origin main && git merge origin/main`, resolve conflicts (re-reconcile counts if README/posters.json changed), re-verify.
@@ -65,6 +74,7 @@ Clones live in the **`studies/`** category at the repo root (the older `template
 - New clones go in `studies/` only, never the repo root or the legacy `templates/`. Use the exact on-disk category name.
 - Capture reference artifacts only with `scrape-ref.mjs`; record demos only with `record-one.sh`; generate posters only with `generate-posters.mjs`. Never hand-roll these.
 - `prompt.md` is uppercase, Markdown, and preserves the verbatim source URL as `REFERENCE:`.
+- The project's own `README.md` is written by the `seo-readme-writer` agent (step 9), never hand-rolled — and because every clone is a study, you must instruct that agent to include the `## Credits` section linking the verbatim `REFERENCE:` URL. The root and `studies/` directory READMEs are still maintained by you.
 - Self-contained output: plain HTML/CSS/JS, assets vendored locally, runnable offline, no build step. Third-party runtime libs (GSAP, Lenis, etc.) are fine, loaded via CDN or vendored.
 - README counts derived from folder counts, never trusted increments; root and category READMEs kept in sync.
 - CLI/headless only — no GUI or computer-use. Show evidence from actual command output, not "it should work".


### PR DESCRIPTION
## What

Adds a dedicated **`seo-readme-writer`** subagent and wires it into both builder agents so each project's own `README.md` is written for SEO/discoverability instead of hand-rolled.

### `seo-readme-writer` (new)
Given one project folder path, it reads that project's `prompt.md`, `package.json`, and source to produce an accurate, SEO-optimized `README.md`:
- keyword-rich, specific H1 (`<Name> — <What it is> (<key tech>)`)
- a lead paragraph ending `Generated with Claude Fable 5.`
- the real `Run` / `Verify` / demo instructions (grounded in the project's files — never fabricated)
- a footer linking back to the category, the root directory, and the live gallery (internal links help SEO)

It also accepts caller-supplied sections verbatim (e.g. a `## Credits` block for clones).

### `fable-experimenter`
Step 10 now delegates the project README to `seo-readme-writer` before registering the project in the root + category directory tables. Added a matching hard rule.

### `template-cloner`
Step 9 now delegates the project README to `seo-readme-writer` and instructs it to include the `## Credits` / Original-source block linking the verbatim `REFERENCE:` URL (carries over the in-flight credits edit). Added a matching hard rule.

The root and category/directory READMEs remain maintained by the build agents — only the per-project README is delegated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)