### PR TITLE
Make scrape-ref.mjs resilient to a blocked Playwright browser CDN

### DIFF
--- a/scripts/record-demos/package.json
+++ b/scripts/record-demos/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"description": "Record smooth demo.mp4 walkthroughs for each Fable landing-page project.",
 	"scripts": {
-		"postinstall": "playwright install chromium",
+		"postinstall": "playwright install chromium || true",
 		"record:all": "bash record-all.sh",
 		"record:one": "bash record-one.sh"
 	},

--- a/scripts/record-demos/scrape-ref.mjs
+++ b/scripts/record-demos/scrape-ref.mjs
@@ -2,6 +2,36 @@ import fs from "node:fs";
 import path from "node:path";
 import { chromium } from "playwright";
 
+// Resolve a Chromium executable. Prefer Playwright's own managed browser, but
+// fall back to a pre-installed Chromium under /opt/pw-browsers when the matching
+// build can't be downloaded (e.g. a sandboxed environment with no access to the
+// Playwright CDN). Returns undefined to let Playwright use its default. Mirrors
+// the resolver in record.mjs so recon works in the same environments as recording.
+function resolveExecutable() {
+	const env = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+	if (env && fs.existsSync(env)) return env;
+	try {
+		const def = chromium.executablePath?.();
+		if (def && fs.existsSync(def)) return undefined; // default is present
+	} catch {
+		/* fall through to the on-disk fallback */
+	}
+	const root = "/opt/pw-browsers";
+	if (!fs.existsSync(root)) return undefined;
+	const dirs = fs.readdirSync(root);
+	const pick = (prefix, leaf) =>
+		dirs
+			.filter((d) => d.startsWith(prefix))
+			.sort()
+			.reverse()
+			.map((d) => `${root}/${d}/chrome-linux/${leaf}`)
+			.find((p) => fs.existsSync(p));
+	return (
+		pick("chromium-", "chrome") ??
+		pick("chromium_headless_shell-", "headless_shell")
+	);
+}
+
 // Usage: node scrape-ref.mjs <url> [outDir]   (or URL=... OUT=... node scrape-ref.mjs)
 const URL = process.argv[2] || process.env.URL;
 const OUT = process.argv[3] || process.env.OUT || "/tmp/scrape-ref";
@@ -11,8 +41,11 @@ if (!URL) {
 }
 fs.mkdirSync(OUT, { recursive: true });
 
-const browser = await chromium.launch();
-const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+const browser = await chromium.launch({ executablePath: resolveExecutable() });
+const page = await browser.newPage({
+	viewport: { width: 1440, height: 900 },
+	ignoreHTTPSErrors: true,
+});
 await page.goto(URL, { waitUntil: "networkidle", timeout: 60000 });
 await page.waitForTimeout(3000);
 


### PR DESCRIPTION
## Why

The `template-cloner` agent failed during recon because `scrape-ref.mjs` couldn't launch a browser. Two issues compounded:

1. `npm install` ran `playwright install chromium`, which hit `cdn.playwright.dev` (not in the environment's egress allowlist) and **failed the whole install**.
2. Even with a Chromium build pre-installed under `/opt/pw-browsers`, `scrape-ref.mjs` called `chromium.launch()` with no `executablePath`, so it tried to use Playwright's (absent) managed build instead of the one on disk.

The sibling `record.mjs` already solved this with a `resolveExecutable()` helper — `scrape-ref.mjs` just didn't reuse it.

## What

- **Port `resolveExecutable()` into `scrape-ref.mjs`** so it falls back to the pre-installed Chromium under `/opt/pw-browsers` when Playwright's managed build is missing (mirrors `record.mjs`).
- **Add `ignoreHTTPSErrors`** to the page so proxy/self-signed TLS doesn't abort capture.
- **Make `postinstall` non-fatal** (`playwright install chromium || true`) so a blocked browser CDN no longer fails `npm install` when a browser already exists.

## Verification

Smoke-tested in this sandbox (Trusted egress, no `cdn.playwright.dev`):

```
node --check scrape-ref.mjs        # SYNTAX OK
npm install                        # NPM INSTALL OK (postinstall no longer fatal)
node scrape-ref.mjs <allowed-url>  # launched via pre-installed Chromium
# → screenshot.png, page.html, outline.json, source.css, sources.json, states/ all produced
```

## Out of scope (environment config, not a repo change)

This PR removes the **browser-launch** blocker. The other half of the original failure was that the template host itself (`ui.aceternity.com`) was blocked by the **Trusted** network policy. To clone templates from arbitrary URLs, set the environment's **Network access** to **Full** (or **Custom** with the relevant template/asset hosts) in the environment editor at claude.ai/code — that part can't be configured from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7rrLvj4xTnrEEw4UqrDBa)_