### PR TITLE
Ignore *-temp.mjs recon scripts in record-demos

### DIFF
--- a/scripts/record-demos/.gitignore
+++ b/scripts/record-demos/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.log
+*-temp.mjs


### PR DESCRIPTION
## Summary

- Adds `*-temp.mjs` to `scripts/record-demos/.gitignore` so temporary per-clone recon scripts (e.g. `scrape-bastion-temp.mjs`) are not tracked

## Test plan
- [ ] Confirm `git status` shows no untracked `*-temp.mjs` files after running a clone recon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmkvFhKR4i5PSrxeqyMXWU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmkvFhKR4i5PSrxeqyMXWU)_