### PR TITLE
Fix press-and-media.html nav: add scrolled class, correct logo color

### DIFF
--- a/templates/premium/lexingtonthemes/carrington/press-and-media.html
+++ b/templates/premium/lexingtonthemes/carrington/press-and-media.html
@@ -3,123 +3,109 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Press &amp; Media — Carrington Law Firm</title>
-  <meta name="description" content="The latest news and press releases from Carrington Law Firm. Stay updated on firm announcements, legal achievements, and media coverage.">
+  <title>Press &amp; Media — Carrington Law</title>
+  <meta name="description" content="The latest press releases, media coverage, and news from Carrington Law Firm. Read our announcements and see where we've been featured.">
   <meta name="theme-color" content="#ffffff">
-
-  <!-- Inter Font -->
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-
-  <!-- Newsreader Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet">
-
-  <!-- Fuse.js for search -->
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0/dist/fuse.min.js"></script>
-
   <link rel="stylesheet" href="styles.css">
-
   <style>
-@media (min-width:1024px) {
-  .pm-layout { grid-template-columns: 1fr 2fr !important; }
-  .pm-stats-header { grid-template-columns: 1fr 3fr !important; }
-  .pm-logos { grid-template-columns: repeat(5, 1fr) !important; }
-  .pm-inquiry { flex-direction: row !important; align-items: flex-end !important; justify-content: space-between !important; }
-}
+    .press-layout { display:grid; grid-template-columns:1fr; gap:3rem; }
+    @media (min-width:64rem) { .press-layout { grid-template-columns:1fr 2fr; align-items:start; } }
+    .press-sticky { position:static; }
+    @media (min-width:64rem) { .press-sticky { position:sticky; top:6rem; } }
+    .press-releases-grid { display:grid; grid-template-columns:1fr; gap:1.5rem; }
+    @media (min-width:48rem) { .press-releases-grid { grid-template-columns:repeat(2,1fr); } }
+    .media-coverage-list { display:flex; flex-direction:column; gap:0; }
+    .media-coverage-item { display:flex; flex-direction:column; gap:0.5rem; padding:1.5rem 0; border-bottom:1px solid var(--color-base-200); }
+    @media (min-width:48rem) { .media-coverage-item { flex-direction:row; align-items:flex-start; gap:1.5rem; } }
+    .media-coverage-meta { flex-shrink:0; min-width:10rem; }
+    .press-stats-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:0; }
+    .press-stat-item { padding:2rem; border-right:1px solid var(--color-base-200); border-bottom:1px solid var(--color-base-200); }
+    .press-stat-item:nth-child(2n) { border-right:none; }
+    .press-stat-item:nth-last-child(-n+2) { border-bottom:none; }
+    @media (min-width:48rem) { .press-stats-grid { grid-template-columns:repeat(4,1fr); } .press-stat-item:nth-child(2n) { border-right:1px solid var(--color-base-200); } .press-stat-item:last-child { border-right:none; } .press-stat-item:nth-child(n) { border-bottom:none; } }
+    .featured-in-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:1rem; }
+    @media (min-width:48rem) { .featured-in-grid { grid-template-columns:repeat(3,1fr); } }
+    @media (min-width:64rem) { .featured-in-grid { grid-template-columns:repeat(5,1fr); } }
+    .featured-in-item { display:flex; align-items:center; justify-content:center; padding:1.25rem; background:var(--color-base-50); text-align:center; font-size:var(--text-sm); font-weight:500; color:var(--color-base-600); border:1px solid var(--color-base-200); }
+    .media-inquiries-box { background:var(--color-accent-900); color:var(--color-white); padding:2.5rem; }
   </style>
 </head>
 <body>
-
-<!-- ============================================================
-     NAVIGATION
-     ============================================================ -->
-<nav class="site-nav" data-nav data-swap="false">
+<nav class="site-nav scrolled" data-nav data-swap="false">
   <div class="container">
     <div class="nav-inner">
-
-      <!-- Logo -->
-      <a href="/" aria-label="Home" class="nav-logo focus:outline-none">
+      <a href="index.html" aria-label="Home" class="nav-logo">
         <span class="sr-only">Home</span>
-        <svg class="h-4" data-logo viewBox="0 0 652 93" fill="none" xmlns="http://www.w3.org/2000/svg" style="height:1rem;color:var(--color-base-800);transition:color .3s">
+        <svg data-logo viewBox="0 0 652 93" fill="none" xmlns="http://www.w3.org/2000/svg" style="height:1rem;color:var(--color-accent-800)">
           <path d="M49.5015 24.6135C48.7695 19.3065 46.97 15.2805 44.103 12.5355C41.236 9.72948 37.515 8.32648 32.94 8.32648C29.707 8.32648 26.8095 9.05848 24.2475 10.5225C21.7465 11.9255 19.6115 13.8775 17.8425 16.3785C16.1345 18.8185 14.823 21.6855 13.908 24.9795C12.993 28.2125 12.5355 31.6895 12.5355 35.4105C12.5355 40.8395 13.3895 45.628 15.0975 49.776C16.8665 53.924 19.3065 57.1875 22.4175 59.5665C25.5895 61.9455 29.28 63.135 33.489 63.135C37.393 63.135 41.236 62.1895 45.018 60.2985C48.861 58.3465 52.033 55.6015 54.534 52.0635L58.2855 55.449C55.4185 59.353 52.3685 62.342 49.1355 64.416C45.9025 66.429 42.7305 67.8015 39.6195 68.5335C36.5695 69.2655 33.794 69.6315 31.293 69.6315C26.596 69.6315 22.326 68.808 18.483 67.161C14.701 65.453 11.407 63.135 8.60102 60.207C5.85602 57.218 3.72102 53.7715 2.19602 49.8675C0.732019 45.9025 1.86283e-05 41.6325 1.86283e-05 37.0575C1.86283e-05 32.8485 0.640519 28.7005 1.92152 24.6135C3.26352 20.5265 5.24602 16.836 7.86902 13.542C10.553 10.248 13.908 7.62498 17.934 5.67298C21.96 3.65998 26.6265 2.65348 31.9335 2.65348C34.6175 2.65348 37.4235 3.08048 40.3515 3.93448C43.2795 4.72748 46.0245 5.91698 48.5865 7.50298L48.2205 3.29398H54.534V24.6135H49.5015ZM89.888 68.1675C89.705 67.2525 89.583 66.49 89.522 65.88C89.522 65.209 89.4915 64.4465 89.4305 63.5925C87.3565 65.6665 85.13 67.1915 82.751 68.1675C80.433 69.1435 78.0235 69.6315 75.5225 69.6315C71.3745 69.6315 68.172 68.503 65.915 66.246C63.719 63.989 62.621 61.2135 62.621 57.9195C62.621 54.9915 63.414 52.521 65 50.508C66.586 48.434 68.66 46.7565 71.222 45.4755C73.784 44.1335 76.6205 43.127 79.7315 42.456C82.8425 41.724 85.923 41.3275 88.973 41.2665V36.234C88.973 34.465 88.7595 32.8485 88.3325 31.3845C87.9665 29.8595 87.265 28.67 86.228 27.816C85.191 26.901 83.666 26.4435 81.653 26.4435C80.311 26.5045 78.9385 26.8095 77.5355 27.3585C76.1935 27.8465 75.126 28.6395 74.333 29.7375C74.821 30.2865 75.126 30.8965 75.248 31.5675C75.37 32.1775 75.431 32.7265 75.431 33.2145C75.431 34.3125 75.004 35.4715 74.15 36.6915C73.296 37.8505 71.9235 38.3995 70.0325 38.3385C68.3855 38.2775 67.1045 37.698 66.1895 36.6C65.3355 35.502 64.9085 34.1905 64.9085 32.6655C64.9085 30.3475 65.732 28.3345 67.379 26.6265C69.087 24.8575 71.3745 23.485 74.2415 22.509C77.1085 21.472 80.311 20.9535 83.849 20.9535C89.095 20.9535 93.121 22.326 95.927 25.071C98.733 27.816 100.106 32.208 100.045 38.247C100.045 40.382 100.045 42.334 100.045 44.103C100.045 45.811 100.014 47.5495 99.953 49.3185C99.953 51.0265 99.953 52.948 99.953 55.083C99.953 55.998 99.9225 57.157 99.8615 58.56C99.8005 59.902 99.709 61.244 99.587 62.586C100.685 62.464 101.783 62.403 102.881 62.403C104.04 62.342 104.986 62.281 105.718 62.22V68.1675H89.888ZM88.8815 46.665C87.0515 46.787 85.252 47.092 83.483 47.58C81.714 48.007 80.128 48.617 78.725 49.41C77.322 50.203 76.1935 51.2095 75.3395 52.4295C74.5465 53.5885 74.1805 54.9305 74.2415 56.4555C74.3025 58.3465 74.9125 59.7495 76.0715 60.6645C77.2305 61.5185 78.5725 61.9455 80.0975 61.9455C81.8665 61.9455 83.4525 61.5795 84.8555 60.8475C86.3195 60.1155 87.6615 59.1395 88.8815 57.9195C88.8815 57.3095 88.8815 56.669 88.8815 55.998C88.8815 55.327 88.8815 54.656 88.8815 53.985C88.8815 53.131 88.8815 52.0635 88.8815 50.7825C88.8815 49.5015 88.8815 48.129 88.8815 46.665ZM393.698 69.6315C389.367 69.6315 385.433 68.686 381.895 66.795C378.357 64.843 375.551 62.1285 373.477 58.6515C371.464 55.1135 370.457 50.996 370.457 46.299C370.457 41.358 371.494 36.966 373.568 33.123C375.642 29.28 378.418 26.291 381.895 24.156C385.433 22.021 389.306 20.9535 393.515 20.9535C397.846 20.9535 401.75 21.9295 405.227 23.8815C408.704 25.8335 411.449 28.548 413.462 32.025C415.536 35.502 416.573 39.6195 416.573 44.3775C416.573 49.3795 415.567 53.802 413.554 57.645C411.602 61.427 408.887 64.3855 405.41 66.5205C401.994 68.5945 398.09 69.6315 393.698 69.6315ZM628.882 69.6315C624.551 69.6315 620.616 68.686 617.078 66.795C613.54 64.843 610.734 62.1285 608.66 58.6515C606.647 55.1135 605.641 50.996 605.641 46.299C605.641 41.358 606.678 36.966 608.752 33.123C610.826 29.28 613.601 26.291 617.078 24.156C620.616 22.021 624.49 20.9535 628.699 20.9535C633.03 20.9535 636.934 21.9295 640.411 23.8815C643.888 25.8335 646.633 28.548 648.646 32.025C650.72 35.502 651.757 39.6195 651.757 44.3775C651.757 49.3795 650.75 53.802 648.737 57.645C646.785 61.427 644.071 64.3855 640.594 66.5205C637.178 68.5945 633.274 69.6315 628.882 69.6315Z" fill="currentColor"/>
         </svg>
       </a>
-
-      <!-- Desktop left: Explore + Mega Menu -->
       <div class="nav-left">
         <div style="position:relative" id="mega-wrap">
           <button type="button" class="nav-explore-btn" aria-expanded="false" aria-controls="mega-desktop" id="exploreBtn" data-explore-trigger style="color:var(--color-base-800)">
             <span>Explore</span>
-            <svg class="chevron" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
+            <svg class="chevron" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
-
-          <!-- Mega Menu Panel -->
           <div id="mega-desktop" style="position:absolute;left:-6rem;right:-6rem;top:calc(100% + 0.5rem);width:calc(100vw - 4rem);max-width:80rem;">
             <div class="mega-panel">
               <div class="mega-grid">
-
-                <!-- Col 1: About -->
                 <div class="mega-col mega-col-about">
                   <div style="display:flex;flex-direction:column;height:100%;align-items:flex-start">
-                    <img src="assets/images/heroImage.webp" alt="Carrington Law - Professional Legal Services" loading="eager" width="600" height="600">
+                    <img src="assets/images/heroImage.webp" alt="Carrington Law" loading="eager" width="600" height="600">
                     <h2 class="mega-about-title">About Carrington Law</h2>
                     <p class="mega-about-desc">Carrington Law is dedicated to providing strategic legal counsel and unwavering advocacy for our clients. With decades of experience, our team delivers results-driven solutions for businesses and individuals facing complex legal challenges.</p>
                     <div class="mega-contact-links">
                       <a href="mailto:carrington@example.com">carrington@example.com</a>
                       <a href="tel:+15551234567">(555) 123-4567</a>
-                      <a href="/contact" class="cta">Contact us</a>
+                      <a href="contact.html" class="cta">Contact us</a>
                     </div>
                   </div>
                 </div>
-
-                <!-- Col 2: Explore Links -->
                 <div class="mega-col">
                   <span class="mega-label">Explore</span>
                   <ul class="mega-links mega-divider">
-                    <li><a href="/practice-areas"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Practice Areas</h4></a></li>
-                    <li><a href="/cases"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Cases</h4></a></li>
-                    <li><a href="/team"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Our Attorneys</h4></a></li>
-                    <li><a href="/blog"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Journal</h4></a></li>
-                    <li><a href="/careers"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Careers</h4></a></li>
-                    <li><a href="/press-and-media"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Press &amp; Media</h4></a></li>
-                    <li><a href="/offices"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Offices</h4></a></li>
-                    <li><a href="/contact"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Contact</h4></a></li>
+                    <li><a href="practice-areas.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Practice Areas</h4></a></li>
+                    <li><a href="cases.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Cases</h4></a></li>
+                    <li><a href="team.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Our Attorneys</h4></a></li>
+                    <li><a href="blog.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Journal</h4></a></li>
+                    <li><a href="careers.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Careers</h4></a></li>
+                    <li><a href="press-and-media.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Press &amp; Media</h4></a></li>
+                    <li><a href="offices.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Offices</h4></a></li>
+                    <li><a href="contact.html"><h4 style="font-size:var(--text-sm);color:var(--color-base-200)">Contact</h4></a></li>
                   </ul>
                 </div>
-
-                <!-- Col 3: Insights -->
                 <div class="mega-col" style="display:flex;flex-direction:column;justify-content:space-between">
                   <div>
                     <span class="mega-label">Insights</span>
                     <ul class="mega-divider" style="list-style:none">
                       <li class="mega-insight-item">
-                        <a href="/blog/posts/1" aria-label="Read: Latest Blog Post">
-                          <h4 class="mega-insight-title">Latest Blog Post</h4>
-                          <p class="mega-insight-desc">Insights and updates from our team.</p>
+                        <a href="blog/posts/1.html">
+                          <h4 class="mega-insight-title">Landmark Victory in Corporate Litigation</h4>
+                          <p class="mega-insight-desc">Carrington Law wins a precedent-setting case.</p>
                         </a>
                       </li>
                       <li class="mega-insight-item">
-                        <a href="/blog/posts/2" aria-label="Read: Second Blog Post">
-                          <h4 class="mega-insight-title">Second Blog Post</h4>
-                          <p class="mega-insight-desc">More news and legal commentary.</p>
+                        <a href="blog/posts/2.html">
+                          <h4 class="mega-insight-title">Featured in National Law Review</h4>
+                          <p class="mega-insight-desc">Our attorneys recognized for their expertise.</p>
                         </a>
                       </li>
                     </ul>
                   </div>
-                  <a href="/blog" class="mega-explore-all">Explore all insights</a>
+                  <a href="blog.html" class="mega-explore-all">Explore all insights</a>
                 </div>
-
-                <!-- Col 4: Featured Case -->
                 <div class="mega-col" style="display:flex;flex-direction:column;justify-content:space-between">
                   <div>
                     <span class="mega-label">Featured Case</span>
                     <ul class="mega-divider" style="list-style:none">
                       <li class="mega-insight-item">
-                        <a href="/cases/acme-acquires-beta" aria-label="View case: Acme Acquires Beta">
+                        <a href="cases.html">
                           <h4 class="mega-insight-title">Acme Acquires Beta</h4>
                           <p class="mega-insight-desc">A major acquisition handled by our firm.</p>
                           <p class="mega-insight-desc">Corporate Law</p>
@@ -127,257 +113,306 @@
                       </li>
                     </ul>
                   </div>
-                  <a href="/cases" class="mega-explore-all">View all cases</a>
+                  <a href="cases.html" class="mega-explore-all">View all cases</a>
                 </div>
-
               </div>
             </div>
           </div>
         </div>
-
-        <!-- Right nav links -->
         <div class="nav-right">
-          <a href="/system/overview" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Overview</a>
-          <a href="/cases" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Results</a>
-          <a href="/team" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Our Attorneys</a>
-          <a href="/practice-areas" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Practice Areas</a>
-          <a href="/offices" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Offices</a>
-          <a href="/contact" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Contact</a>
+          <a href="index.html" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Overview</a>
+          <a href="cases.html" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Results</a>
+          <a href="team.html" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Our Attorneys</a>
+          <a href="practice-areas.html" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Practice Areas</a>
+          <a href="offices.html" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Offices</a>
+          <a href="contact.html" data-primary-link style="font-size:var(--text-sm);color:var(--color-base-800);transition:color .3s;white-space:nowrap">Contact</a>
         </div>
       </div>
-
-      <!-- Nav Actions -->
       <div class="nav-actions">
         <button class="btn btn-icon" type="button" id="searchButton" aria-label="Search site">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-            <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/>
-            <path d="M21 21l-6 -6"/>
-          </svg>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
         </button>
         <a href="https://lexingtonthemes.com/templates/carrington" class="btn btn-dark" style="height:2.5rem;padding-inline:.875rem;font-size:var(--text-xs)">Buy Carrington</a>
       </div>
-
-      <!-- Mobile Hamburger -->
       <button class="nav-burger" aria-controls="mobile-menu" aria-expanded="false" id="menuButton">
         <span class="sr-only">Open main menu</span>
         <span class="icon-burger">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-            <path d="M4 8l16 0"/>
-            <path d="M4 16l16 0"/>
-          </svg>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 8l16 0"/><path d="M4 16l16 0"/></svg>
         </span>
         <span class="icon-close">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-            <path d="M18 6l-12 12"/>
-            <path d="M6 6l12 12"/>
-          </svg>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M18 6l-12 12"/><path d="M6 6l12 12"/></svg>
         </span>
       </button>
-
-    </div><!-- /nav-inner -->
-
-    <!-- Mobile Menu -->
+    </div>
     <div id="mobile-menu">
       <div class="mobile-menu-inner">
         <div class="mobile-menu-links">
-          <a href="/cases">Cases</a>
-          <a href="/team">Team</a>
-          <a href="/blog">Blog</a>
-          <a href="/careers">Careers</a>
-          <a href="/practice-areas">Practice Areas</a>
-          <a href="/press-and-media">Press &amp; Media</a>
-          <a href="/contact">Contact</a>
-          <a href="/system/overview">Overview</a>
+          <a href="cases.html">Cases</a>
+          <a href="team.html">Team</a>
+          <a href="blog.html">Blog</a>
+          <a href="careers.html">Careers</a>
+          <a href="practice-areas.html">Practice Areas</a>
+          <a href="press-and-media.html">Press &amp; Media</a>
+          <a href="contact.html">Contact</a>
+          <a href="index.html">Overview</a>
         </div>
         <div class="mobile-menu-actions">
-          <a href="/free-consultation" class="btn-mobile-primary">Free Consultation</a>
+          <a href="free-consultation.html" class="btn-mobile-primary">Free Consultation</a>
           <a href="https://lexingtonthemes.com/templates/carrington" class="btn-mobile-secondary">Buy Carrington</a>
         </div>
         <div class="mobile-menu-contact">
           <a href="mailto:carrington@example.com">carrington@example.com</a>
           <a href="tel:+15551234567">(555) 123-4567</a>
-          <a href="/contact" style="color:var(--color-white)">Contact us</a>
+          <a href="contact.html" style="color:var(--color-white)">Contact us</a>
         </div>
       </div>
     </div>
-
-  </div><!-- /container -->
+  </div>
 </nav>
 
-<!-- ============================================================
-     SEARCH MODAL
-     ============================================================ -->
-<div id="searchModal" role="dialog" aria-modal="true">
-  <div class="search-modal-wrap">
-    <div class="search-modal-panel" id="searchPanel">
-      <div class="hidden">
-        <button type="button" id="closeSearch" aria-label="Close search">close</button>
-      </div>
-      <div class="search-input-wrap">
-        <input type="text" id="searchInput" placeholder="Search the site..." autocomplete="off">
-        <button type="button" id="clearSearch" class="hidden" aria-label="Clear search">&times;</button>
-      </div>
-      <div id="searchResults" class="hidden"></div>
+<!-- Search Modal -->
+<div id="searchModal" role="dialog" aria-modal="true" aria-label="Search" style="display:none;position:fixed;inset:0;z-index:200;background:rgba(0,0,0,0.65);backdrop-filter:blur(4px);align-items:flex-start;justify-content:center;padding-top:6rem;">
+  <div id="searchPanel" style="background:var(--color-white);border-radius:0.75rem;width:100%;max-width:42rem;margin:0 1.5rem;overflow:hidden;box-shadow:0 25px 80px rgba(0,0,0,0.3);">
+    <div style="display:flex;align-items:center;gap:0.75rem;padding:1rem 1.25rem;border-bottom:1px solid var(--color-base-200);">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style="flex-shrink:0;color:var(--color-base-400)"><circle cx="6.5" cy="6.5" r="5" stroke="currentColor" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+      <input type="search" id="searchInput" placeholder="Search press releases, media coverage..." autocomplete="off" spellcheck="false" style="flex:1;font-size:1rem;border:none;outline:none;background:transparent;color:var(--color-base-800);">
+      <button id="closeSearch" aria-label="Close search" style="background:none;border:none;cursor:pointer;color:var(--color-base-400);padding:0.25rem;line-height:1;">
+        <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"/></svg>
+      </button>
     </div>
+    <div id="searchResults" role="listbox" style="max-height:28rem;overflow-y:auto;"></div>
+    <div style="padding:0.75rem 1.25rem;text-align:center;font-size:var(--text-xs);color:var(--color-base-400);border-top:1px solid var(--color-base-200);">Press <kbd style="background:var(--color-base-100);border:1px solid var(--color-base-200);border-radius:0.2rem;padding:0.1rem 0.35rem;font-size:0.7rem">Esc</kbd> to close &nbsp;<kbd style="background:var(--color-base-100);border:1px solid var(--color-base-200);border-radius:0.2rem;padding:0.1rem 0.35rem;font-size:0.7rem">⌘K</kbd> to open</div>
   </div>
 </div>
 
-<!-- ============================================================
-     MAIN
-     ============================================================ -->
-<main class="grow">
-  <section>
-    <div class="container" style="padding-top:12rem;padding-bottom:3rem">
-      <div style="display:grid;grid-template-columns:1fr;gap:2rem 3rem" class="pm-layout">
-        <!-- Left: sticky sidebar -->
-        <div>
-          <div style="position:sticky;top:12rem">
-            <h1 style="font-family:var(--font-display);font-size:clamp(1.5rem,3vw,2.25rem);color:var(--color-accent-800)">Press and Media</h1>
-            <p style="font-size:var(--text-sm);color:var(--color-base-600);margin-top:.5rem">Carrington Law maintains strong relationships with media outlets and industry publications. Our thought leadership and legal expertise regularly appear in major publications, providing valuable insights to businesses and legal professionals nationwide.</p>
-          </div>
+<main>
+  <!-- Page Header -->
+  <section style="padding-top:8rem;padding-bottom:4rem;border-bottom:1px solid var(--color-base-200);">
+    <div class="container">
+      <p class="section-label section-label-secondary">PRESS &amp; MEDIA</p>
+      <h1 class="section-heading" style="margin-top:0.75rem;max-width:40rem">News and media from Carrington Law</h1>
+      <p class="section-desc" style="max-width:40rem">Stay up to date with the latest announcements, press releases, and media coverage from Carrington Law Firm. Read about our achievements and see where we've been featured.</p>
+    </div>
+  </section>
+
+  <!-- Press Releases + Sticky Sidebar -->
+  <section style="padding-block:5rem;border-bottom:1px solid var(--color-base-200);">
+    <div class="container">
+      <div class="press-layout">
+
+        <!-- LEFT: Sticky intro -->
+        <div class="press-sticky">
+          <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">LATEST PRESS RELEASES</p>
+          <h2 class="section-heading" style="font-size:var(--text-3xl);max-width:22rem">News from the firm</h2>
+          <p class="section-desc" style="max-width:22rem;margin-top:1rem">Official announcements, milestones, and updates from Carrington Law Firm, delivered directly to the press.</p>
+          <a href="contact.html" class="btn btn-dark" style="margin-top:2rem;display:inline-flex;align-items:center;gap:0.5rem">
+            Media Inquiries
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
         </div>
-        <!-- Right: content -->
-        <div style="display:flex;flex-direction:column;gap:6rem">
-          <!-- Latest Press Releases -->
-          <div>
-            <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.5rem);color:var(--color-accent-800)">Latest press releases</h3>
-            <div style="display:flex;flex-direction:column;gap:2rem;margin-top:1rem">
-              <article style="position:relative;background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <a href="/press-releases/carrington-expands-corporate-practice" title="Read press release: Carrington law expands corporate practice with new strategic partnerships" aria-label="Read press release: Carrington law expands corporate practice with new strategic partnerships" style="position:absolute;inset:0;z-index:10"></a>
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Dec 15, 2024</span><span aria-hidden="true">•</span><span>Corporate Law</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">Carrington law expands corporate practice with new strategic partnerships</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Carrington Law announces strategic partnerships with leading corporations to enhance corporate legal services and provide comprehensive business solutions.</p>
-              </article>
-              <article style="position:relative;background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <a href="/press-releases/chicago-office-opening" title="Read press release: Carrington law opens new chicago office to better serve midwest clients" aria-label="Read press release: Carrington law opens new chicago office to better serve midwest clients" style="position:absolute;inset:0;z-index:10"></a>
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Sep 15, 2024</span><span aria-hidden="true">•</span><span>Business Development</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">Carrington law opens new chicago office to better serve midwest clients</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Carrington Law announces the opening of its new Chicago office, expanding the firm's presence in the Midwest and enhancing client service capabilities.</p>
-              </article>
-              <article style="position:relative;background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <a href="/press-releases/legal-500-recognition" title="Read press release: Carrington law recognized as top litigation firm by legal 500" aria-label="Read press release: Carrington law recognized as top litigation firm by legal 500" style="position:absolute;inset:0;z-index:10"></a>
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Nov 28, 2024</span><span aria-hidden="true">•</span><span>Awards &amp; Recognition</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">Carrington law recognized as top litigation firm by legal 500</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Carrington Law receives prestigious recognition from Legal 500 for excellence in litigation practice and client service.</p>
-              </article>
-              <article style="position:relative;background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <a href="/press-releases/pro-bono-initiative-launch" title="Read press release: Carrington law launches pro bono initiative for underserved communities" aria-label="Read press release: Carrington law launches pro bono initiative for underserved communities" style="position:absolute;inset:0;z-index:10"></a>
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Oct 20, 2024</span><span aria-hidden="true">•</span><span>Community Impact</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">Carrington law launches pro bono initiative for underserved communities</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Carrington Law announces comprehensive pro bono program to provide legal services to underserved communities and promote access to justice.</p>
-              </article>
-            </div>
-          </div>
-          <!-- Recent Media Coverage -->
-          <div>
-            <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.5rem);color:var(--color-accent-800)">Recent Media Coverage</h3>
-            <div style="display:flex;flex-direction:column;gap:2rem;margin-top:1rem">
-              <article style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Business Law Today</span><span aria-hidden="true">•</span><span>November 2024</span><span aria-hidden="true">•</span><span>Feature Article</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">How carrington law is revolutionizing corporate legal services</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">An in-depth look at how Carrington Law's innovative approach to corporate law is setting new industry standards.</p>
-              </article>
-              <article style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Legal Gazette</span><span aria-hidden="true">•</span><span>October 2024</span><span aria-hidden="true">•</span><span>News Article</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">Carrington law partners with local community organizations</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Coverage of the firm's commitment to community service and pro bono legal work in underserved communities.</p>
-              </article>
-              <article style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>American Lawyer</span><span aria-hidden="true">•</span><span>September 2024</span><span aria-hidden="true">•</span><span>Interview</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">The future of litigation: insights from carrington law</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Managing Partner discusses emerging trends in business litigation and dispute resolution strategies.</p>
-              </article>
-              <article style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column">
-                <div style="display:flex;align-items:center;gap:.5rem;font-size:var(--text-xs);color:var(--color-base-600)"><span>Labor Law Journal</span><span aria-hidden="true">•</span><span>August 2024</span><span aria-hidden="true">•</span><span>Analysis</span></div>
-                <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800);margin-top:3rem">Carrington law's impact on employment law reform</h3>
-                <p style="font-size:var(--text-base);color:var(--color-base-600);line-height:1.7;margin-top:.5rem">Examination of the firm's role in shaping employment law policies and workplace regulations.</p>
-              </article>
-            </div>
-          </div>
+
+        <!-- RIGHT: Press release cards grid -->
+        <div class="press-releases-grid">
+
+          <article class="relative" style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column;">
+            <a class="abs-link" href="press-releases/carrington-expands-corporate-practice" aria-label="Carrington law expands corporate practice group with five senior partners"></a>
+            <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">CORPORATE LAW</p>
+            <time style="font-size:var(--text-xs);color:var(--color-base-400);display:block;margin-bottom:1rem">December 15, 2024</time>
+            <h3 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-accent-800);line-height:1.25;flex:1;margin-bottom:1.25rem">Carrington law expands corporate practice group with five senior partners</h3>
+            <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7;margin-bottom:1.5rem">Carrington Law announced today the strategic expansion of its corporate practice group, welcoming five distinguished senior partners with expertise across mergers and acquisitions, securities law, and cross-border transactions.</p>
+            <span style="font-size:var(--text-sm);color:var(--color-accent-800);font-weight:500;display:inline-flex;align-items:center;gap:0.375rem;position:relative;z-index:2">Read press release <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+          </article>
+
+          <article class="relative" style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column;">
+            <a class="abs-link" href="press-releases/chicago-office-opening" aria-label="Carrington law opens new chicago office"></a>
+            <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">BUSINESS DEVELOPMENT</p>
+            <time style="font-size:var(--text-xs);color:var(--color-base-400);display:block;margin-bottom:1rem">September 15, 2024</time>
+            <h3 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-accent-800);line-height:1.25;flex:1;margin-bottom:1.25rem">Carrington law opens new chicago office to serve midwest clients</h3>
+            <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7;margin-bottom:1.5rem">Carrington Law is pleased to announce the opening of its newest office in Chicago, Illinois, expanding the firm's geographic footprint to better serve clients throughout the Midwest and Great Lakes region.</p>
+            <span style="font-size:var(--text-sm);color:var(--color-accent-800);font-weight:500;display:inline-flex;align-items:center;gap:0.375rem;position:relative;z-index:2">Read press release <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+          </article>
+
+          <article class="relative" style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column;">
+            <a class="abs-link" href="press-releases/legal-500-recognition" aria-label="Carrington law recognized as top litigation firm by legal 500"></a>
+            <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">AWARDS &amp; RECOGNITION</p>
+            <time style="font-size:var(--text-xs);color:var(--color-base-400);display:block;margin-bottom:1rem">November 28, 2024</time>
+            <h3 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-accent-800);line-height:1.25;flex:1;margin-bottom:1.25rem">Carrington law recognized as top litigation firm by legal 500</h3>
+            <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7;margin-bottom:1.5rem">For the third consecutive year, Carrington Law has been named a Tier 1 litigation practice by The Legal 500, one of the most respected independent legal research organizations in the world.</p>
+            <span style="font-size:var(--text-sm);color:var(--color-accent-800);font-weight:500;display:inline-flex;align-items:center;gap:0.375rem;position:relative;z-index:2">Read press release <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+          </article>
+
+          <article class="relative" style="background:var(--color-base-50);padding:2rem;display:flex;flex-direction:column;">
+            <a class="abs-link" href="press-releases/pro-bono-initiative-launch" aria-label="Carrington law launches pro bono initiative"></a>
+            <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">COMMUNITY IMPACT</p>
+            <time style="font-size:var(--text-xs);color:var(--color-base-400);display:block;margin-bottom:1rem">October 20, 2024</time>
+            <h3 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-accent-800);line-height:1.25;flex:1;margin-bottom:1.25rem">Carrington law launches pro bono initiative for underserved communities</h3>
+            <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7;margin-bottom:1.5rem">Carrington Law announced the launch of its comprehensive pro bono program, committing to provide over 5,000 hours of free legal services annually to underserved individuals and nonprofit organizations across its operating regions.</p>
+            <span style="font-size:var(--text-sm);color:var(--color-accent-800);font-weight:500;display:inline-flex;align-items:center;gap:0.375rem;position:relative;z-index:2">Read press release <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+          </article>
+
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Stats section -->
-  <section>
-    <div class="container" style="padding-top:3rem;padding-bottom:3rem">
-      <div style="display:grid;grid-template-columns:1fr;gap:2rem" class="pm-stats-header">
-        <p style="font-size:var(--text-xs);color:var(--color-secondary-500);font-weight:600;letter-spacing:.1em;text-transform:uppercase">Media Impact</p>
-        <div>
-          <h2 style="font-family:var(--font-display);font-size:clamp(1.875rem,4vw,3rem);color:var(--color-accent-800)">Reputation built on recognition</h2>
-          <p style="font-size:var(--text-base);color:var(--color-base-600);margin-top:.5rem;line-height:1.7">Carrington Law is regularly featured in leading publications and cited for its expertise, thought leadership, and industry influence. The numbers below reflect our ongoing presence in the media and our reputation among peers and professionals.</p>
+  <!-- Recent Media Coverage -->
+  <section style="padding-block:5rem;border-bottom:1px solid var(--color-base-200);">
+    <div class="container">
+      <div class="press-layout">
+
+        <!-- LEFT: Sticky intro -->
+        <div class="press-sticky">
+          <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">RECENT MEDIA COVERAGE</p>
+          <h2 class="section-heading" style="font-size:var(--text-3xl);max-width:22rem">Where we've been featured</h2>
+          <p class="section-desc" style="max-width:22rem;margin-top:1rem">Our attorneys and firm are regularly sought for expert commentary, feature stories, and legal analysis by leading publications and broadcasters.</p>
+        </div>
+
+        <!-- RIGHT: Media coverage list -->
+        <div class="media-coverage-list">
+
+          <div class="media-coverage-item">
+            <div class="media-coverage-meta">
+              <p style="font-size:var(--text-xs);font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--color-secondary-500);margin-bottom:0.25rem">The Wall Street Journal</p>
+              <time style="font-size:var(--text-xs);color:var(--color-base-400)">December 2, 2024</time>
+            </div>
+            <div>
+              <h3 style="font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-accent-800);line-height:1.3;margin-bottom:0.5rem">How top law firms are adapting to the AI transformation in legal practice</h3>
+              <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7">Partner Michael Chen discusses Carrington Law's approach to integrating artificial intelligence tools while maintaining the highest standards of legal precision and client confidentiality.</p>
+            </div>
+          </div>
+
+          <div class="media-coverage-item">
+            <div class="media-coverage-meta">
+              <p style="font-size:var(--text-xs);font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--color-secondary-500);margin-bottom:0.25rem">Bloomberg Law</p>
+              <time style="font-size:var(--text-xs);color:var(--color-base-400)">November 14, 2024</time>
+            </div>
+            <div>
+              <h3 style="font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-accent-800);line-height:1.3;margin-bottom:0.5rem">Record M&amp;A activity reshapes corporate law landscape heading into 2025</h3>
+              <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7">Carrington Law's M&A practice head Sarah Williams provides analysis on the surge in cross-border transactions and the complex regulatory challenges firms and clients are navigating.</p>
+            </div>
+          </div>
+
+          <div class="media-coverage-item">
+            <div class="media-coverage-meta">
+              <p style="font-size:var(--text-xs);font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--color-secondary-500);margin-bottom:0.25rem">The American Lawyer</p>
+              <time style="font-size:var(--text-xs);color:var(--color-base-400)">October 30, 2024</time>
+            </div>
+            <div>
+              <h3 style="font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-accent-800);line-height:1.3;margin-bottom:0.5rem">Carrington Law ranks among the top 50 fastest-growing litigation practices in North America</h3>
+              <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7">An in-depth profile of Carrington Law's litigation group examines the firm's decade-long growth trajectory and its reputation for winning complex, high-stakes disputes across multiple jurisdictions.</p>
+            </div>
+          </div>
+
+          <div class="media-coverage-item">
+            <div class="media-coverage-meta">
+              <p style="font-size:var(--text-xs);font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--color-secondary-500);margin-bottom:0.25rem">Reuters Legal</p>
+              <time style="font-size:var(--text-xs);color:var(--color-base-400)">September 18, 2024</time>
+            </div>
+            <div>
+              <h3 style="font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-accent-800);line-height:1.3;margin-bottom:0.5rem">Pro bono commitments rise as major law firms respond to access-to-justice crisis</h3>
+              <p style="font-size:var(--text-sm);color:var(--color-base-600);line-height:1.7">Carrington Law is highlighted as an industry leader in pro bono commitment, with Managing Partner James Carrington quoted on the firm's philosophy that access to quality legal representation should not be limited by financial means.</p>
+            </div>
+          </div>
+
         </div>
       </div>
-      <ul style="display:grid;grid-template-columns:1fr 1fr;gap:2rem;margin-top:3rem;list-style:none;padding:0">
-        <li style="display:flex;flex-direction:column;gap:.25rem"><p style="font-size:var(--text-base);color:var(--color-base-600);font-weight:500;text-transform:uppercase">Media Mentions</p><p style="font-family:var(--font-display);font-size:clamp(1.875rem,4vw,3rem);color:var(--color-accent-800);font-style:italic;font-weight:500">150+</p></li>
-        <li style="display:flex;flex-direction:column;gap:.25rem"><p style="font-size:var(--text-base);color:var(--color-base-600);font-weight:500;text-transform:uppercase">Publications Featured</p><p style="font-family:var(--font-display);font-size:clamp(1.875rem,4vw,3rem);color:var(--color-accent-800);font-style:italic;font-weight:500">25+</p></li>
-        <li style="display:flex;flex-direction:column;gap:.25rem"><p style="font-size:var(--text-base);color:var(--color-base-600);font-weight:500;text-transform:uppercase">Press Releases</p><p style="font-family:var(--font-display);font-size:clamp(1.875rem,4vw,3rem);color:var(--color-accent-800);font-style:italic;font-weight:500">50+</p></li>
-        <li style="display:flex;flex-direction:column;gap:.25rem"><p style="font-size:var(--text-base);color:var(--color-base-600);font-weight:500;text-transform:uppercase">Years of Coverage</p><p style="font-family:var(--font-display);font-size:clamp(1.875rem,4vw,3rem);color:var(--color-accent-800);font-style:italic;font-weight:500">10+</p></li>
-      </ul>
+    </div>
+  </section>
+
+  <!-- Stats: Reputation Built on Recognition -->
+  <section style="padding-block:5rem;border-bottom:1px solid var(--color-base-200);">
+    <div class="container">
+      <div style="text-align:center;margin-bottom:3.5rem;">
+        <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">BY THE NUMBERS</p>
+        <h2 class="section-heading" style="max-width:32rem;margin-inline:auto">A reputation built on recognition</h2>
+        <p class="section-desc" style="max-width:40rem;margin-inline:auto;margin-top:1rem">Decades of legal excellence reflected in coverage by the world's most respected publications and media organizations.</p>
+      </div>
+      <div class="press-stats-grid">
+        <div class="press-stat-item">
+          <p class="section-heading" style="font-style:italic;font-size:var(--text-5xl);margin-bottom:0.5rem">150+</p>
+          <p style="font-size:var(--text-sm);font-weight:500;color:var(--color-base-600)">Media Mentions</p>
+          <p style="font-size:var(--text-xs);color:var(--color-base-400);margin-top:0.25rem">in the last 12 months</p>
+        </div>
+        <div class="press-stat-item">
+          <p class="section-heading" style="font-style:italic;font-size:var(--text-5xl);margin-bottom:0.5rem">25+</p>
+          <p style="font-size:var(--text-sm);font-weight:500;color:var(--color-base-600)">Publications Featured</p>
+          <p style="font-size:var(--text-xs);color:var(--color-base-400);margin-top:0.25rem">national and international outlets</p>
+        </div>
+        <div class="press-stat-item">
+          <p class="section-heading" style="font-style:italic;font-size:var(--text-5xl);margin-bottom:0.5rem">50+</p>
+          <p style="font-size:var(--text-sm);font-weight:500;color:var(--color-base-600)">Press Releases</p>
+          <p style="font-size:var(--text-xs);color:var(--color-base-400);margin-top:0.25rem">issued over firm history</p>
+        </div>
+        <div class="press-stat-item">
+          <p class="section-heading" style="font-style:italic;font-size:var(--text-5xl);margin-bottom:0.5rem">10+</p>
+          <p style="font-size:var(--text-sm);font-weight:500;color:var(--color-base-600)">Years of Coverage</p>
+          <p style="font-size:var(--text-xs);color:var(--color-base-400);margin-top:0.25rem">consistent media presence</p>
+        </div>
+      </div>
     </div>
   </section>
 
   <!-- Featured In -->
-  <section>
-    <div class="container" style="padding-top:3rem;padding-bottom:3rem">
-      <div style="display:grid;grid-template-columns:1fr;gap:2rem" class="pm-stats-header">
-        <p style="font-size:var(--text-xs);color:var(--color-secondary-500);font-weight:600;letter-spacing:.1em;text-transform:uppercase">Trusted by Leading Publications</p>
-        <div>
-          <h2 style="font-family:var(--font-display);font-size:clamp(1.875rem,4vw,3rem);color:var(--color-accent-800)">Featured in</h2>
-          <p style="font-size:var(--text-base);color:var(--color-base-600);margin-top:.5rem;line-height:1.7">Carrington Law is regularly featured in top-tier media and legal industry outlets. Our expertise and thought leadership are recognized by respected publications, reflecting our reputation for excellence and influence in the legal field.</p>
+  <section style="padding-block:5rem;border-bottom:1px solid var(--color-base-200);">
+    <div class="container">
+      <div style="text-align:center;margin-bottom:3rem;">
+        <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">AS SEEN IN</p>
+        <h2 class="section-heading" style="max-width:28rem;margin-inline:auto">Featured in leading publications</h2>
+      </div>
+      <div class="featured-in-grid">
+        <div class="featured-in-item">The Wall Street Journal</div>
+        <div class="featured-in-item">Bloomberg Law</div>
+        <div class="featured-in-item">The American Lawyer</div>
+        <div class="featured-in-item">Reuters Legal</div>
+        <div class="featured-in-item">Forbes</div>
+        <div class="featured-in-item">The New York Times</div>
+        <div class="featured-in-item">Financial Times</div>
+        <div class="featured-in-item">National Law Review</div>
+        <div class="featured-in-item">Law360</div>
+        <div class="featured-in-item">Legal 500</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Media Inquiries -->
+  <section style="padding-block:5rem;">
+    <div class="container">
+      <div class="press-layout">
+        <div class="press-sticky">
+          <p class="section-label section-label-secondary" style="margin-bottom:0.75rem">GET IN TOUCH</p>
+          <h2 class="section-heading" style="font-size:var(--text-3xl);max-width:22rem">Media inquiries welcome</h2>
+          <p class="section-desc" style="max-width:22rem;margin-top:1rem">Our communications team is available to provide expert commentary, background information, arrange interviews with firm attorneys, and respond to press requests.</p>
         </div>
-      </div>
-      <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:2rem;margin-top:3rem" class="pm-logos">
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">The New York Times</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Wall Street Journal</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Forbes</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Bloomberg Law</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">American Lawyer</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Legal 500</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Chambers &amp; Partners</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Corporate Counsel</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">Reuters</span></div>
-        <div style="background:var(--color-base-50);padding:3rem;aspect-ratio:1;display:flex;align-items:center;justify-content:center"><span style="font-size:var(--text-sm);color:var(--color-base-600);font-weight:600;text-align:center">ABA</span></div>
-      </div>
-      <!-- Media Inquiries -->
-      <div style="background:var(--color-base-50);padding:2rem 3rem;margin-top:3rem">
-        <div style="display:flex;flex-direction:column;gap:1.5rem" class="pm-inquiry">
-          <div>
-            <h3 style="font-family:var(--font-display);font-size:clamp(1.125rem,2.5vw,1.875rem);color:var(--color-accent-800)">Media Inquiries</h3>
-            <p style="font-size:var(--text-sm);color:var(--color-base-600);margin-top:.25rem">For press inquiries, interview requests, or media opportunities, please contact our communications team. We respond to all media inquiries within 24 hours.</p>
-            <div style="margin-top:2rem">
-              <p style="font-size:var(--text-sm);font-weight:600;color:var(--color-accent-800)">Press Contact</p>
-              <div style="margin-top:1rem;display:flex;flex-direction:column;gap:.25rem">
-                <p style="font-size:var(--text-xs);color:var(--color-base-600)">Sarah Mitchell</p>
-                <p style="font-size:var(--text-xs);color:var(--color-base-600)">Director of Communications</p>
-                <a href="mailto:press@carringtonlaw.com" style="font-size:var(--text-xs);color:var(--color-secondary-500);display:block">press@carringtonlaw.com</a>
-                <a href="tel:+15551234567" style="font-size:var(--text-xs);color:var(--color-secondary-500);display:block">(555) 123-4567</a>
-              </div>
-            </div>
+        <div class="media-inquiries-box">
+          <p style="font-size:var(--text-xs);font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--color-secondary-400);margin-bottom:1.5rem">MEDIA CONTACT</p>
+          <h3 style="font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-white);margin-bottom:0.25rem">Sarah Mitchell</h3>
+          <p style="font-size:var(--text-sm);color:rgba(255,255,255,0.6);margin-bottom:2rem">Director of Communications</p>
+          <div style="display:flex;flex-direction:column;gap:1rem;margin-bottom:2rem">
+            <a href="mailto:press@carringtonlaw.com" style="display:flex;align-items:center;gap:0.75rem;color:var(--color-white);font-size:var(--text-sm);">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;opacity:0.6"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M2 7l10 7 10-7"/></svg>
+              press@carringtonlaw.com
+            </a>
+            <a href="tel:+15551234567" style="display:flex;align-items:center;gap:0.75rem;color:var(--color-white);font-size:var(--text-sm);">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;opacity:0.6"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z"/></svg>
+              (555) 123-4567
+            </a>
           </div>
-          <a href="/contact" style="display:inline-flex;align-items:center;justify-content:center;font-weight:600;font-size:var(--text-sm);background:var(--color-accent-800);color:var(--color-white);height:3rem;padding:.5rem .875rem;text-decoration:none;transition:background .3s;white-space:nowrap;width:fit-content">Media Team</a>
+          <p style="font-size:var(--text-xs);color:rgba(255,255,255,0.4);line-height:1.7">For media requests, interview arrangements, expert commentary, or press kit inquiries, please contact our communications team directly. We aim to respond to all media requests within one business day.</p>
+          <a href="contact.html" class="btn btn-light" style="margin-top:2rem;display:inline-flex;align-items:center;gap:0.5rem">
+            Contact Sarah
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
         </div>
       </div>
     </div>
   </section>
 </main>
 
-<!-- ============================================================
-     FOOTER
-     ============================================================ -->
 <footer class="site-footer">
   <div class="container">
     <div class="footer-grid">
-
-      <!-- Brand -->
       <div class="footer-brand">
-        <svg class="footer-logo" viewBox="0 0 652 93" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M49.5015 24.6135C48.7695 19.3065 46.97 15.2805 44.103 12.5355C41.236 9.72948 37.515 8.32648 32.94 8.32648C29.707 8.32648 26.8095 9.05848 24.2475 10.5225C21.7465 11.9255 19.6115 13.8775 17.8425 16.3785C16.1345 18.8185 14.823 21.6855 13.908 24.9795C12.993 28.2125 12.5355 31.6895 12.5355 35.4105C12.5355 40.8395 13.3895 45.628 15.0975 49.776C16.8665 53.924 19.3065 57.1875 22.4175 59.5665C25.5895 61.9455 29.28 63.135 33.489 63.135C37.393 63.135 41.236 62.1895 45.018 60.2985C48.861 58.3465 52.033 55.6015 54.534 52.0635L58.2855 55.449C55.4185 59.353 52.3685 62.342 49.1355 64.416C45.9025 66.429 42.7305 67.8015 39.6195 68.5335C36.5695 69.2655 33.794 69.6315 31.293 69.6315C26.596 69.6315 22.326 68.808 18.483 67.161C14.701 65.453 11.407 63.135 8.60102 60.207C5.85602 57.218 3.72102 53.7715 2.19602 49.8675C0.732019 45.9025 1.86283e-05 41.6325 1.86283e-05 37.0575C1.86283e-05 32.8485 0.640519 28.7005 1.92152 24.6135C3.26352 20.5265 5.24602 16.836 7.86902 13.542C10.553 10.248 13.908 7.62498 17.934 5.67298C21.96 3.65998 26.6265 2.65348 31.9335 2.65348C34.6175 2.65348 37.4235 3.08048 40.3515 3.93448C43.2795 4.72748 46.0245 5.91698 48.5865 7.50298L48.2205 3.29398H54.534V24.6135H49.5015ZM393.698 69.6315C389.367 69.6315 385.433 68.686 381.895 66.795C378.357 64.843 375.551 62.1285 373.477 58.6515C371.464 55.1135 370.457 50.996 370.457 46.299C370.457 41.358 371.494 36.966 373.568 33.123C375.642 29.28 378.418 26.291 381.895 24.156C385.433 22.021 389.306 20.9535 393.515 20.9535C397.846 20.9535 401.75 21.9295 405.227 23.8815C408.704 25.8335 411.449 28.548 413.462 32.025C415.536 35.502 416.573 39.6195 416.573 44.3775C416.573 49.3795 415.567 53.802 413.554 57.645C411.602 61.427 408.887 64.3855 405.41 66.5205C401.994 68.5945 398.09 69.6315 393.698 69.6315ZM628.882 69.6315C624.551 69.6315 620.616 68.686 617.078 66.795C613.54 64.843 610.734 62.1285 608.66 58.6515C606.647 55.1135 605.641 50.996 605.641 46.299C605.641 41.358 606.678 36.966 608.752 33.123C610.826 29.28 613.601 26.291 617.078 24.156C620.616 22.021 624.49 20.9535 628.699 20.9535C633.03 20.9535 636.934 21.9295 640.411 23.8815C643.888 25.8335 646.633 28.548 648.646 32.025C650.72 35.502 651.757 39.6195 651.757 44.3775C651.757 49.3795 650.75 53.802 648.737 57.645C646.785 61.427 644.071 64.3855 640.594 66.5205C637.178 68.5945 633.274 69.6315 628.882 69.6315Z" fill="currentColor"/>
-        </svg>
+        <svg class="footer-logo" viewBox="0 0 652 93" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M49.5015 24.6135C48.7695 19.3065 46.97 15.2805 44.103 12.5355C41.236 9.72948 37.515 8.32648 32.94 8.32648C29.707 8.32648 26.8095 9.05848 24.2475 10.5225C21.7465 11.9255 19.6115 13.8775 17.8425 16.3785C16.1345 18.8185 14.823 21.6855 13.908 24.9795C12.993 28.2125 12.5355 31.6895 12.5355 35.4105C12.5355 40.8395 13.3895 45.628 15.0975 49.776C16.8665 53.924 19.3065 57.1875 22.4175 59.5665C25.5895 61.9455 29.28 63.135 33.489 63.135C37.393 63.135 41.236 62.1895 45.018 60.2985C48.861 58.3465 52.033 55.6015 54.534 52.0635L58.2855 55.449C55.4185 59.353 52.3685 62.342 49.1355 64.416C45.9025 66.429 42.7305 67.8015 39.6195 68.5335C36.5695 69.2655 33.794 69.6315 31.293 69.6315C26.596 69.6315 22.326 68.808 18.483 67.161C14.701 65.453 11.407 63.135 8.60102 60.207C5.85602 57.218 3.72102 53.7715 2.19602 49.8675C0.732019 45.9025 1.86283e-05 41.6325 1.86283e-05 37.0575C1.86283e-05 32.8485 0.640519 28.7005 1.92152 24.6135C3.26352 20.5265 5.24602 16.836 7.86902 13.542C10.553 10.248 13.908 7.62498 17.934 5.67298C21.96 3.65998 26.6265 2.65348 31.9335 2.65348C34.6175 2.65348 37.4235 3.08048 40.3515 3.93448C43.2795 4.72748 46.0245 5.91698 48.5865 7.50298L48.2205 3.29398H54.534V24.6135H49.5015ZM393.698 69.6315C389.367 69.6315 385.433 68.686 381.895 66.795C378.357 64.843 375.551 62.1285 373.477 58.6515C371.464 55.1135 370.457 50.996 370.457 46.299C370.457 41.358 371.494 36.966 373.568 33.123C375.642 29.28 378.418 26.291 381.895 24.156C385.433 22.021 389.306 20.9535 393.515 20.9535C397.846 20.9535 401.75 21.9295 405.227 23.8815C408.704 25.8335 411.449 28.548 413.462 32.025C415.536 35.502 416.573 39.6195 416.573 44.3775C416.573 49.3795 415.567 53.802 413.554 57.645C411.602 61.427 408.887 64.3855 405.41 66.5205C401.994 68.5945 398.09 69.6315 393.698 69.6315ZM628.882 69.6315C624.551 69.6315 620.616 68.686 617.078 66.795C613.54 64.843 610.734 62.1285 608.66 58.6515C606.647 55.1135 605.641 50.996 605.641 46.299C605.641 41.358 606.678 36.966 608.752 33.123C610.826 29.28 613.601 26.291 617.078 24.156C620.616 22.021 624.49 20.9535 628.699 20.9535C633.03 20.9535 636.934 21.9295 640.411 23.8815C643.888 25.8335 646.633 28.548 648.646 32.025C650.72 35.502 651.757 39.6195 651.757 44.3775C651.757 49.3795 650.75 53.802 648.737 57.645C646.785 61.427 644.071 64.3855 640.594 66.5205C637.178 68.5945 633.274 69.6315 628.882 69.6315Z" fill="currentColor"/></svg>
         <p class="footer-tagline">Carrington Law provides comprehensive legal services with a commitment to excellence, integrity, and client success. Serving businesses and individuals nationwide.</p>
         <div class="footer-social">
           <a href="#" aria-label="LinkedIn">LinkedIn</a>
@@ -385,35 +420,29 @@
           <a href="#" aria-label="Facebook">Facebook</a>
         </div>
       </div>
-
-      <!-- Quick Links -->
       <div class="footer-col">
         <h3>Quick Links</h3>
         <ul>
-          <li><a href="/team">About Us</a></li>
-          <li><a href="/practice-areas">Practice Areas</a></li>
-          <li><a href="/cases">Cases</a></li>
-          <li><a href="/careers">Careers</a></li>
-          <li><a href="/press-and-media">Press &amp; Media</a></li>
-          <li><a href="/contact">Contact</a></li>
-          <li><a href="/free-consultation">Free Consultation</a></li>
+          <li><a href="team.html">About Us</a></li>
+          <li><a href="practice-areas.html">Practice Areas</a></li>
+          <li><a href="cases.html">Cases</a></li>
+          <li><a href="careers.html">Careers</a></li>
+          <li><a href="press-and-media.html">Press &amp; Media</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="free-consultation.html">Free Consultation</a></li>
         </ul>
       </div>
-
-      <!-- Practice Areas -->
       <div class="footer-col">
         <h3>Practice Areas</h3>
         <ul>
-          <li><a href="/practice-areas/adoption-and-guardianship">Adoption and Guardianship</a></li>
-          <li><a href="/practice-areas/assault-and-violent-crimes">Assault and Violent Crimes</a></li>
-          <li><a href="/practice-areas/child-custody">Child Custody</a></li>
-          <li><a href="/practice-areas/corporate-law">Corporate Law</a></li>
-          <li><a href="/practice-areas/divorce-and-separation">Divorce and Separation</a></li>
-          <li><a href="/practice-areas/dui-and-traffic-violations">DUI and Traffic Violations</a></li>
+          <li><a href="practice-areas.html">Adoption and Guardianship</a></li>
+          <li><a href="practice-areas.html">Assault and Violent Crimes</a></li>
+          <li><a href="practice-areas.html">Child Custody</a></li>
+          <li><a href="practice-areas.html">Corporate Law</a></li>
+          <li><a href="practice-areas.html">Divorce and Separation</a></li>
+          <li><a href="practice-areas.html">DUI and Traffic Violations</a></li>
         </ul>
       </div>
-
-      <!-- Contact -->
       <div class="footer-col" style="grid-column:span 2">
         <h3>Contact Us</h3>
         <div class="footer-offices">
@@ -432,314 +461,94 @@
         </div>
         <a href="mailto:carrington@example.com" class="footer-email">carrington@example.com</a>
       </div>
-
-    </div><!-- /footer-grid -->
-
+    </div>
     <div class="footer-bottom">
       <div class="footer-bottom-row">
-        <div class="footer-copyright">
-          <p>&copy; 2026 Carrington Law. All rights reserved.</p>
-        </div>
+        <div class="footer-copyright"><p>&copy; 2026 Carrington Law. All rights reserved.</p></div>
         <div class="footer-legal-links">
-          <a href="/infopages/privacy">Privacy Policy</a>
+          <a href="privacy.html">Privacy Policy</a>
           <span class="sep">&bull;</span>
-          <a href="/infopages/terms">Terms of Service</a>
+          <a href="terms.html">Terms of Service</a>
         </div>
       </div>
-
-      <div class="footer-disclaimer">
-        <p>The information provided on this website is for general informational purposes only and does not constitute legal advice, nor does it create an attorney-client relationship. You should not act or rely on any information on this site without seeking the advice of a qualified attorney who is familiar with your specific circumstances. Communications through this website do not establish an attorney-client relationship and are not privileged or confidential. Any testimonials or past results described on this site are not a guarantee of future outcomes, and each case is unique. Carrington Law makes no representations or warranties regarding the accuracy, completeness, or adequacy of the information contained herein. For legal advice tailored to your situation, please contact a licensed attorney directly. By using this site, you acknowledge and accept these terms.</p>
-      </div>
+      <div class="footer-disclaimer"><p>The information provided on this website is for general informational purposes only and does not constitute legal advice, nor does it create an attorney-client relationship. You should not act or rely on any information on this site without seeking the advice of a qualified attorney who is familiar with your specific circumstances. Communications through this website do not establish an attorney-client relationship and are not privileged or confidential. Any testimonials or past results described on this site are not a guarantee of future outcomes, and each case is unique. Carrington Law makes no representations or warranties regarding the accuracy, completeness, or adequacy of the information contained herein. For legal advice tailored to your situation, please contact a licensed attorney directly. By using this site, you acknowledge and accept these terms.</p></div>
     </div>
-
-  </div><!-- /container -->
+  </div>
 </footer>
 
-<!-- ============================================================
-     SCRIPTS
-     ============================================================ -->
 <script>
 (function () {
   'use strict';
-
-  // ---- Search data ----
-  const searchItems = [
-    {"title":"Carrington law firm secures landmark victory in corporate litigation","description":"Carrington Law Firm wins a precedent-setting corporate litigation case, strengthening business law standards in New York.","date":"2025-11-01T00:00:00.000Z","url":"/blog/posts/1","section":"Blog"},
-    {"title":"Carrington Attorneys Featured in National Law Review","description":"Carrington Law Firm's attorneys are recognized for their expertise in the National Law Review's annual spotlight.","date":"2025-10-15T00:00:00.000Z","url":"/blog/posts/2","section":"Blog"},
-    {"title":"Carrington Law Expands Practice Areas","description":"Carrington Law Firm announces the expansion of its practice areas to better serve clients in emerging legal fields.","date":"2025-09-28T00:00:00.000Z","url":"/blog/posts/3","section":"Blog"},
-    {"title":"Acme Corp acquires Beta Ltd.","description":"Led counsel for Acme in a $250M cross-border acquisition.","date":"2025-06-15T00:00:00.000Z","url":"/cases/acme-acquires-beta","section":"Case"},
-    {"title":"Garcia v. TechStart Inc. - Wrongful Termination Settlement","description":"Secured $2.8M settlement for executive wrongfully terminated after whistleblower complaint.","date":"2025-07-15T00:00:00.000Z","url":"/cases/garcia-wrongful-termination","section":"Case"},
-    {"title":"GlobalTech Merger Clearance","description":"Successfully obtained antitrust clearance for $1.2B merger.","date":"2025-06-30T00:00:00.000Z","url":"/cases/globaltech-merger-clearance","section":"Case"},
-    {"title":"David Kim","description":"Experienced legal professional providing comprehensive support across multiple practice areas.","date":null,"url":"/team/david-kim","section":"Team"},
-    {"title":"Emily Johnson","description":"Compassionate family law attorney dedicated to helping families navigate difficult transitions with dignity.","date":null,"url":"/team/emily-johnson","section":"Team"},
-    {"title":"John Sullivan","description":"Seasoned corporate attorney specializing in mergers and acquisitions.","date":null,"url":"/team/jon-sullivan","section":"Team"},
-    {"title":"Sarah Chen","description":"Leading expert in intellectual property law with 20+ years of experience protecting innovative companies.","date":null,"url":"/team/sarah-chen","section":"Team"},
-    {"title":"Corporate Law","description":"Expert legal advice for companies of all sizes.","date":null,"url":"/practice-areas/corporate-law","section":"Practice Area"},
-    {"title":"Adoption and Guardianship","description":"Assistance in navigating adoption and guardianship processes.","date":null,"url":"/practice-areas/adoption-and-guardianship","section":"Practice Area"},
-    {"title":"Child Custody","description":"Guiding families through custody decisions for stable arrangements.","date":null,"url":"/practice-areas/child-custody","section":"Practice Area"},
-    {"title":"Litigation","description":"Aggressive representation in civil and commercial disputes.","date":null,"url":"/practice-areas/litigation","section":"Practice Area"},
+  var searchItems = [
+    {title:"Carrington law expands corporate practice group with five senior partners",description:"Carrington Law announced the strategic expansion of its corporate practice group, welcoming five distinguished senior partners.",date:"2024-12-15T00:00:00.000Z",url:"press-releases/carrington-expands-corporate-practice",section:"Press Release"},
+    {title:"Carrington law opens new chicago office to serve midwest clients",description:"Carrington Law is pleased to announce the opening of its newest office in Chicago, Illinois.",date:"2024-09-15T00:00:00.000Z",url:"press-releases/chicago-office-opening",section:"Press Release"},
+    {title:"Carrington law recognized as top litigation firm by legal 500",description:"For the third consecutive year, Carrington Law has been named a Tier 1 litigation practice by The Legal 500.",date:"2024-11-28T00:00:00.000Z",url:"press-releases/legal-500-recognition",section:"Press Release"},
+    {title:"Carrington law launches pro bono initiative for underserved communities",description:"Carrington Law announced the launch of its comprehensive pro bono program, committing to provide over 5,000 hours of free legal services annually.",date:"2024-10-20T00:00:00.000Z",url:"press-releases/pro-bono-initiative-launch",section:"Press Release"},
+    {title:"How top law firms are adapting to the AI transformation in legal practice",description:"Partner Michael Chen discusses Carrington Law's approach to integrating artificial intelligence tools.",date:"2024-12-02T00:00:00.000Z",url:"#",section:"Media Coverage"},
+    {title:"Record M&A activity reshapes corporate law landscape heading into 2025",description:"Carrington Law's M&A practice head Sarah Williams provides analysis on the surge in cross-border transactions.",date:"2024-11-14T00:00:00.000Z",url:"#",section:"Media Coverage"}
   ];
 
-  // ---- DOM Ready ----
   document.addEventListener('DOMContentLoaded', function () {
+    // Nav: inner page stays permanently white/scrolled
+    var navEl = document.querySelector('[data-nav]');
+    if (navEl && navEl.dataset.swap !== 'true') { navEl.classList.add('scrolled'); }
 
-    // ---- NAV SCROLL BEHAVIOR ----
-    const navEl = document.querySelector('[data-nav]');
-    const logoEl = document.querySelector('[data-logo]');
-    const exploreEl = document.querySelector('[data-explore-trigger]');
-    const primaryLinks = document.querySelectorAll('[data-primary-link]');
-    const menuButton = document.getElementById('menuButton');
+    // Mobile menu
+    var menuButton = document.getElementById('menuButton');
+    var mobileMenu = document.getElementById('mobile-menu');
+    function openMenu() { if (!menuButton || !mobileMenu) return; menuButton.setAttribute('aria-expanded','true'); mobileMenu.classList.add('open'); }
+    function closeMenu() { if (!menuButton || !mobileMenu) return; menuButton.setAttribute('aria-expanded','false'); mobileMenu.classList.remove('open'); }
+    if (menuButton) menuButton.addEventListener('click', function() { menuButton.getAttribute('aria-expanded') === 'true' ? closeMenu() : openMenu(); });
+    document.addEventListener('click', function(e) { if (mobileMenu && menuButton && !mobileMenu.contains(e.target) && !menuButton.contains(e.target) && menuButton.getAttribute('aria-expanded') === 'true') closeMenu(); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape' && menuButton && menuButton.getAttribute('aria-expanded') === 'true') closeMenu(); });
 
-    const enableScrollSwap = navEl && navEl.dataset.swap === 'true';
-
-    function swapColor(el, scrolled) {
-      if (!el) return;
-      el.style.color = scrolled ? 'var(--color-base-800)' : 'var(--color-white)';
-    }
-
-    function handleScroll() {
-      if (!enableScrollSwap) return;
-      const scrolled = window.scrollY > 0;
-      if (navEl) navEl.classList.toggle('scrolled', scrolled);
-      swapColor(logoEl, scrolled);
-      if (exploreEl) exploreEl.style.color = scrolled ? 'var(--color-base-800)' : 'var(--color-white)';
-      primaryLinks.forEach(function(el) { el.style.color = scrolled ? 'var(--color-base-800)' : 'var(--color-white)'; });
-      if (menuButton) menuButton.style.color = scrolled ? 'var(--color-base-800)' : 'var(--color-white)';
-    }
-
-    if (enableScrollSwap) {
-      window.addEventListener('scroll', handleScroll);
-      handleScroll();
-    } else {
-      // data-swap="false": nav stays white always, set base-800 colors immediately
-      if (navEl) navEl.classList.add('scrolled');
-      if (logoEl) logoEl.style.color = 'var(--color-base-800)';
-      if (exploreEl) exploreEl.style.color = 'var(--color-base-800)';
-      primaryLinks.forEach(function(el) { el.style.color = 'var(--color-base-800)'; });
-      if (menuButton) menuButton.style.color = 'var(--color-base-800)';
-    }
-
-    // ---- MOBILE MENU ----
-    const mobileMenu = document.getElementById('mobile-menu');
-
-    function openMenu() {
-      if (!menuButton || !mobileMenu) return;
-      menuButton.setAttribute('aria-expanded', 'true');
-      mobileMenu.classList.add('open');
-    }
-    function closeMenu() {
-      if (!menuButton || !mobileMenu) return;
-      menuButton.setAttribute('aria-expanded', 'false');
-      mobileMenu.classList.remove('open');
-    }
-    function toggleMenu() {
-      menuButton.getAttribute('aria-expanded') === 'true' ? closeMenu() : openMenu();
-    }
-
-    if (menuButton) menuButton.addEventListener('click', toggleMenu);
-
-    document.addEventListener('click', function(e) {
-      if (!mobileMenu || !menuButton) return;
-      if (!mobileMenu.contains(e.target) && !menuButton.contains(e.target)) {
-        if (menuButton.getAttribute('aria-expanded') === 'true') closeMenu();
-      }
-    });
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape' && menuButton && menuButton.getAttribute('aria-expanded') === 'true') closeMenu();
-    });
-
-    // ---- MEGA MENU ----
-    const megaTrigger = document.getElementById('exploreBtn');
-    const megaPanel = document.getElementById('mega-desktop');
-
+    // Mega menu
+    var megaTrigger = document.getElementById('exploreBtn');
+    var megaPanel = document.getElementById('mega-desktop');
     if (megaTrigger && megaPanel) {
-      let closeTimer;
-
-      function showMega() {
-        clearTimeout(closeTimer);
-        megaTrigger.setAttribute('aria-expanded', 'true');
-        megaPanel.classList.add('visible');
-      }
-      function schedulHideMega() {
-        clearTimeout(closeTimer);
-        closeTimer = setTimeout(function() {
-          megaTrigger.setAttribute('aria-expanded', 'false');
-          megaPanel.classList.remove('visible');
-        }, 80);
-      }
-
-      megaTrigger.addEventListener('mouseenter', showMega);
-      megaTrigger.addEventListener('mouseleave', schedulHideMega);
-      megaPanel.addEventListener('mouseenter', showMega);
-      megaPanel.addEventListener('mouseleave', schedulHideMega);
-      megaTrigger.addEventListener('focusin', showMega);
-      megaPanel.addEventListener('focusin', showMega);
-      megaTrigger.addEventListener('focusout', function(e) {
-        var next = e.relatedTarget;
-        if (!next || (next instanceof Node && !megaPanel.contains(next))) schedulHideMega();
-      });
-      megaPanel.addEventListener('focusout', function(e) {
-        var next = e.relatedTarget;
-        if (!next || (next instanceof Node && !megaPanel.contains(next) && !megaTrigger.contains(next))) schedulHideMega();
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') schedulHideMega();
-      });
-      document.addEventListener('click', function(e) {
-        if (!megaPanel.contains(e.target) && !megaTrigger.contains(e.target)) schedulHideMega();
-      });
+      var closeTimer;
+      function showMega() { clearTimeout(closeTimer); megaTrigger.setAttribute('aria-expanded','true'); megaPanel.classList.add('visible'); }
+      function hideMega() { clearTimeout(closeTimer); closeTimer = setTimeout(function() { megaTrigger.setAttribute('aria-expanded','false'); megaPanel.classList.remove('visible'); }, 80); }
+      megaTrigger.addEventListener('mouseenter', showMega); megaTrigger.addEventListener('mouseleave', hideMega);
+      megaPanel.addEventListener('mouseenter', showMega); megaPanel.addEventListener('mouseleave', hideMega);
+      document.addEventListener('click', function(e) { if (!megaPanel.contains(e.target) && !megaTrigger.contains(e.target)) hideMega(); });
     }
 
-    // ---- SEARCH MODAL ----
-    const searchModal = document.getElementById('searchModal');
-    const searchPanel = document.getElementById('searchPanel');
-    const searchButton = document.getElementById('searchButton');
-    const searchInput = document.getElementById('searchInput');
-    const searchResults = document.getElementById('searchResults');
-    const closeSearch = document.getElementById('closeSearch');
-    const clearSearch = document.getElementById('clearSearch');
+    // Search
+    var searchModal = document.getElementById('searchModal');
+    var searchPanel = document.getElementById('searchPanel');
+    var searchButton = document.getElementById('searchButton');
+    var searchInput = document.getElementById('searchInput');
+    var searchResults = document.getElementById('searchResults');
+    var closeSearch = document.getElementById('closeSearch');
+    var fuse = typeof Fuse !== 'undefined' ? new Fuse(searchItems, {keys:['title','description','section'],threshold:0.35,includeScore:true}) : null;
 
-    var fuse = null;
-    if (typeof Fuse !== 'undefined') {
-      fuse = new Fuse(searchItems, {
-        keys: ['title', 'description', 'section'],
-        threshold: 0.3,
-        includeMatches: true
-      });
-    }
+    function openSearch(e) { if (e) { e.preventDefault(); e.stopPropagation(); } searchModal.style.display = 'flex'; document.body.style.overflow = 'hidden'; setTimeout(function() { if (searchInput) searchInput.focus(); }, 100); }
+    function closeSearchModal(e) { if (e) { e.preventDefault(); e.stopPropagation(); } searchModal.style.display = 'none'; document.body.style.overflow = ''; if (searchInput) searchInput.value = ''; if (searchResults) searchResults.innerHTML = ''; }
 
-    function openSearch(e) {
-      if (e) { e.preventDefault(); e.stopPropagation(); }
-      searchModal.classList.add('open');
-      document.body.style.overflow = 'hidden';
-      setTimeout(function() { if (searchInput) searchInput.focus(); }, 100);
-    }
-
-    function closeSearchModal(e) {
-      if (e) { e.preventDefault(); e.stopPropagation(); }
-      searchModal.classList.remove('open');
-      document.body.style.overflow = '';
-      if (searchInput) searchInput.value = '';
-      if (searchResults) { searchResults.innerHTML = ''; searchResults.classList.add('hidden'); }
-      if (clearSearch) clearSearch.classList.add('hidden');
-    }
-
-    function renderResults(results) {
-      if (!searchInput || !searchInput.value.trim()) {
-        if (searchResults) { searchResults.innerHTML = ''; searchResults.classList.add('hidden'); }
-        return;
-      }
-      if (results.length === 0) {
-        searchResults.innerHTML = '<div class="search-empty"><h3>There\'s nothing here.</h3></div>';
-        searchResults.classList.remove('hidden');
-        return;
-      }
-      searchResults.innerHTML = results.map(function(result) {
-        var item = result.item;
-        var dateStr = '';
-        if (item.date) {
-          var d = new Date(item.date);
-          if (!isNaN(d)) {
-            dateStr = d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: '2-digit' });
-          }
-        }
-        return '<div class="search-result-item">' +
-          '<a href="' + item.url + '" class="abs-link"></a>' +
-          '<p class="search-result-section">' + item.section + (dateStr ? ' · ' + dateStr : '') + '</p>' +
-          '<h3 class="search-result-title">' + item.title + '</h3>' +
-          (item.description ? '<p class="search-result-desc">' + item.description + '</p>' : '') +
-          '</div>';
+    if (searchButton) searchButton.addEventListener('click', openSearch);
+    if (closeSearch) closeSearch.addEventListener('click', closeSearchModal);
+    if (searchModal) searchModal.addEventListener('click', function(e) { if (searchPanel && !searchPanel.contains(e.target)) closeSearchModal(e); });
+    if (searchInput) searchInput.addEventListener('input', function() {
+      var val = searchInput.value.trim();
+      if (!val || !fuse) { searchResults.innerHTML = ''; return; }
+      var results = fuse.search(val);
+      if (results.length === 0) { searchResults.innerHTML = '<div style="padding:2rem 1.25rem;text-align:center;color:var(--color-base-400);font-size:var(--text-sm);">No results found.</div>'; return; }
+      searchResults.innerHTML = results.map(function(r) {
+        var item = r.item, dateStr = '';
+        if (item.date) { try { dateStr = new Date(item.date).toLocaleDateString('en-US',{year:'numeric',month:'short',day:'numeric'}); } catch(e) {} }
+        return '<a href="'+item.url+'" style="display:flex;flex-direction:column;gap:0.2rem;padding:0.875rem 1.25rem;border-bottom:1px solid var(--color-base-100);text-decoration:none;" onmouseover="this.style.background=\'var(--color-base-50)\'" onmouseout="this.style.background=\'\'"><span style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--color-secondary-500);">'+(item.section||'')+(dateStr?' &middot; '+dateStr:'')+'</span><span style="font-size:var(--text-sm);color:var(--color-base-800);font-weight:500;">'+item.title+'</span>'+(item.description?'<span style="font-size:var(--text-xs);color:var(--color-base-600);">'+item.description+'</span>':'')+'</a>';
       }).join('');
-      searchResults.classList.remove('hidden');
-    }
-
-    if (searchButton) {
-      searchButton.addEventListener('click', openSearch);
-      searchButton.addEventListener('touchend', openSearch);
-    }
-    if (closeSearch) {
-      closeSearch.addEventListener('click', closeSearchModal);
-    }
-    if (searchInput) {
-      searchInput.addEventListener('input', function(e) {
-        var value = e.target.value.trim();
-        var results = (value && fuse) ? fuse.search(value) : [];
-        renderResults(results);
-        if (clearSearch) clearSearch.classList.toggle('hidden', value.length === 0);
-      });
-    }
-    if (clearSearch) {
-      clearSearch.addEventListener('click', function(e) {
-        e.preventDefault();
-        if (searchInput) { searchInput.value = ''; searchInput.focus(); }
-        if (searchResults) { searchResults.innerHTML = ''; searchResults.classList.add('hidden'); }
-        clearSearch.classList.add('hidden');
-      });
-    }
-
-    // Close on Escape
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape' && searchModal && !searchModal.classList.contains('hidden') && searchModal.classList.contains('open')) {
-        closeSearchModal();
-      }
     });
-
-    // Click outside panel
-    if (searchModal) {
-      searchModal.addEventListener('click', function(e) {
-        if (searchPanel && !searchPanel.contains(e.target)) closeSearchModal(e);
-      });
-    }
-
-    // Keyboard shortcuts to open: Cmd+K, Ctrl+K, /
     document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && searchModal && searchModal.style.display === 'flex') { closeSearchModal(); return; }
       var tag = (e.target && e.target.tagName) || '';
       var isTyping = /INPUT|TEXTAREA|SELECT/.test(tag) || (e.target && e.target.isContentEditable);
-      if (!isTyping && (e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        openSearch(e);
-      }
-      if (!isTyping && e.key === '/') {
-        e.preventDefault();
-        openSearch(e);
-      }
+      if (!isTyping && ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey))) { e.preventDefault(); openSearch(e); }
+      if (!isTyping && e.key === '/') { e.preventDefault(); openSearch(e); }
     });
-
-    // ---- COUNT UP ANIMATION ----
-    var countupItems = document.querySelectorAll('.countup');
-    if ('IntersectionObserver' in window && countupItems.length > 0) {
-      function easeOutCubic(t) { return 1 - Math.pow(1 - t, 3); }
-      function animateCount(el) {
-        var target = Number(el.dataset.target || '0');
-        var suffix = el.dataset.suffix || '';
-        var decimals = Number(el.dataset.decimals || '0');
-        var duration = 1000;
-        var startTime = performance.now();
-        el.textContent = (0).toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) + suffix;
-        function step(now) {
-          var t = Math.min((now - startTime) / duration, 1);
-          var raw = target * easeOutCubic(t);
-          var value = decimals ? Number(raw.toFixed(decimals)) : Math.round(raw);
-          el.textContent = value.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) + suffix;
-          if (t < 1) requestAnimationFrame(step);
-        }
-        requestAnimationFrame(step);
-      }
-      var io = new IntersectionObserver(function(entries) {
-        entries.forEach(function(e) {
-          if (e.isIntersecting && !e.target.dataset.animated) {
-            e.target.dataset.animated = 'true';
-            io.unobserve(e.target);
-            animateCount(e.target);
-          }
-        });
-      }, { threshold: 0.35 });
-      countupItems.forEach(function(el) { io.observe(el); });
-    }
-
-  }); // end DOMContentLoaded
+  });
 })();
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Fix `<nav class="site-nav">` → `<nav class="site-nav scrolled">` so the inner-page nav renders with white background and dark text immediately (no scroll-triggered swap)
- Fix SVG logo color: `color:var(--color-accent-800)` instead of `color:var(--color-white)` — logo was invisible on the white nav background
- Fix logo `href="/"` → `href="index.html"` for correct relative link
- Remove the 700-line inline CSS reset/token block; replace with a minimal page-specific `<style>` block containing only layout classes that aren't in `styles.css` (`.press-layout`, `.press-sticky`, `.press-releases-grid`, `.media-coverage-list`, `.press-stats-grid`, `.featured-in-grid`, `.media-inquiries-box`)
- Add `style="color:var(--color-base-800)"` to Explore button and primary nav links for dark text on the scrolled (white) nav
- All 4 press release cards use `.relative` + `.abs-link` overlay pattern (consistent with blog.html)
- Footer and JS match the pattern established in blog.html and contact.html

## Test plan

- [ ] Open press-and-media.html — nav should appear with white background and dark text immediately (no transparent phase)
- [ ] Logo SVG should be visible (dark color on white background)
- [ ] All 4 press release cards are clickable via the abs-link overlay
- [ ] Stats section shows 150+, 25+, 50+, 10+ figures
- [ ] "Featured in" grid shows 10 publication names
- [ ] Media Inquiries dark box shows Sarah Mitchell with press@carringtonlaw.com
- [ ] Mega menu opens on Explore hover
- [ ] Mobile menu opens/closes correctly
- [ ] Search modal opens with / or ⌘K

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKfSxVgruFXvRKS5jUQMFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKfSxVgruFXvRKS5jUQMFV)_