### PR TITLE
Reconcile template/project counts to disk (60 templates, 360 projects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (359)
+## Projects (360)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -393,7 +393,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Templates (59)</b></summary>
+<summary><b>Templates (60)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-**59 website template experiments generated with Claude Fable 5** — multi-page site templates and same-to-same clones of real-world designs, rebuilt as self-contained HTML/CSS/JS and React/Tailwind projects. A reference collection of AI-generated, full website templates. Part of the [claude-directory](../README.md) ([live gallery](https://pulkitxm.com/claude-directory)).
+**60 website template experiments generated with Claude Fable 5** — multi-page site templates and same-to-same clones of real-world designs, rebuilt as self-contained HTML/CSS/JS and React/Tailwind projects. A reference collection of AI-generated, full website templates. Part of the [claude-directory](../README.md) ([live gallery](https://pulkitxm.com/claude-directory)).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
Two PRs — salient (#443) and protocol (#438) — merged close together, which left the README count headers one behind the actual on-disk folder count.

This bumps the headers to match disk (verified: 60 leaf `prompt.md`, 360 `demo.mp4`, 360 `posters.json` entries):
- root `README.md`: `## Projects (359 → 360)`, `Templates (59 → 60)`
- `templates/README.md`: `59 → 60 website template experiments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019nwJmWPq5ypiDVvWRdkgbk)_