### PR TITLE
Fix template/project counts after concurrent merges (75/375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once your `demo.mp4` is in, generate its poster so the directory can show a shar
 
 All PRs get reviewed and merged by Claude Opus, so don't be shy — if the prompt and demo are there, you're golden. 🤙
 
-## Projects (374)
+## Projects (375)
 
 Projects are grouped by what they are. Each lives in its category folder (e.g. `./hero-sections/<project>/`).
 
@@ -393,7 +393,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Templates (74)</b></summary>
+<summary><b>Templates (75)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-**74 website template experiments generated with Claude Fable 5** — multi-page site templates and same-to-same clones of real-world designs, rebuilt as self-contained HTML/CSS/JS and React/Tailwind projects. A reference collection of AI-generated, full website templates. Part of the [claude-directory](../README.md) ([live gallery](https://pulkitxm.com/claude-directory)).
+**75 website template experiments generated with Claude Fable 5** — multi-page site templates and same-to-same clones of real-world designs, rebuilt as self-contained HTML/CSS/JS and React/Tailwind projects. A reference collection of AI-generated, full website templates. Part of the [claude-directory](../README.md) ([live gallery](https://pulkitxm.com/claude-directory)).
 
 | Project | Description | Stack |
 |---------|-------------|-------|


### PR DESCRIPTION
## Summary

Reconciles the headline counts in the root `README.md` and `templates/README.md` to the actual on-disk leaf counts.

PRs #450 (`commit`) and #453 (`syntax`) merged concurrently and both incremented the counts from the same merge base (`73 → 74`). Git collapsed the identical edit, leaving every total one short. The repository actually contains **75 template leaf folders** and **375 projects** (verified via `git ls-tree -r` on the merged `main`).

### Changes
- root `README.md`: `## Projects (374)` → `## Projects (375)`
- root `README.md`: `Templates (74)` → `Templates (75)`
- `templates/README.md`: `**74 website template experiments…` → `**75…`

No content rows change — both `commit` and `syntax` rows are already present; only the summary numbers were stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jtd9o7UgKPUMBWotL8yLBp)_