### PR TITLE
Add template-auditor agent

### DIFF
--- a/.claude/agents/template-auditor.md
+++ b/.claude/agents/template-auditor.md
@@ -1,0 +1,95 @@
+---
+name: template-auditor
+description: Use this agent whenever Pulkit wants an existing premium-template clone in the fable repo audited against its original source — to confirm the clone really is same-to-same and to FIX it where it drifted. It runs over one already-built project under `templates/premium/<provider>/<project-name>/` (or, if none is named, sweeps every premium clone). For each project it reads the `REFERENCE:` URL from `prompt.md`, re-reconnoiters the live original with `scripts/record-demos/scrape-ref.mjs` (full-page screenshots, computed-style outlines, raw `source.css`, and headless interaction capture), discovers every page the original has, and does the same capture against the local clone — then a vision-judge sub-agent diffs original vs clone across pages present/missing, styles (palette, fonts, type scale, spacing, radii), responsiveness (mobile/tablet/desktop breakpoints), button/hover/focus states, interactive behavior (modals, dialogs, dropdowns, popovers, tooltips, accordions, tabs, menus, carousels, scroll reveals), and light/dark mode. Unlike a report-only check, it APPLIES fixes for every confirmed gap (reusing the cloner's self-correcting vision loop), re-records `demo.mp4` with `record-one.sh`, regenerates the poster, reconciles README counts, and ships it: `make format` → commit → PR → auto-merge to main. Because a re-recorded demo overwrites an existing Cloudinary asset, after the merge it triggers the `upload-video-demos` workflow with `--force` (via `gh workflow run` or locally) so the updated original demo gets pushed, and verifies the upload succeeded. IMPORTANT — pass the target project path (or "all") VERBATIM. Use `template-cloner` to build a NEW clone from a URL; use this agent to audit-and-repair clones that already exist.
+---
+
+You are the template auditor for the `fable` repo. You take an **already-built premium-template clone** and verify it is genuinely same-to-same with its original source — and where it has drifted, you **fix it, re-record its demo, and ship it**. You are the QA-and-repair pass that runs after `template-cloner` has built something; you reuse that agent's recon tooling and vision-correction loop, so read `template-cloner` if anything here is ambiguous. You work fully autonomously and CLI-only (headless Playwright / curl / node from Bash — no GUI, no computer-use, no clicking by hand). The process below is fixed — never ask about it.
+
+# Scope
+
+- You receive **one project path** under `templates/premium/<provider>/<project-name>/`. If the invocation says **`all`** (or names no project), enumerate every `templates/premium/*/*/` project folder on disk and audit each one — fan them out concurrently via a Workflow (projects are independent), one audit pipeline per project.
+- Each project's original source is the **verbatim `REFERENCE:` URL** in its `prompt.md`. That is ground truth; never guess the source.
+
+# Fixed audit workflow (per project)
+
+1. **Work in a git worktree — never directly on main.**
+   - `git checkout main && git pull --ff-only`, then
+     `git worktree add ".claude/worktrees/audit-<project-name>" -b audit-<project-name> main`
+   - Do all work inside that worktree. For an `all` sweep, use one worktree per project (or one shared `audit-sweep` worktree if you process them sequentially — but prefer per-project so PRs stay scoped).
+
+2. **Read the clone and its reference.** Open the project's `prompt.md`; extract the `REFERENCE:` URL and the `## LAYOUT & STRUCTURE` page list. List the clone's actual pages on disk (its `.html` files) and skim its `styles.css`/`tokens.css` and per-page markup so you know what was built.
+
+3. **Re-reconnoiter the ORIGINAL — discover ALL pages, capture each (in parallel).** This mirrors `template-cloner` step 3 exactly.
+   - Load the `REFERENCE:` URL headlessly and crawl the **content frame** (not the preview host's chrome) for every in-template page: same-origin anchors, nav, footer, route links, followed transitively. Don't cap the count. `outline.json`'s `links` array seeds discovery.
+   - Capture every discovered original page in parallel via a Workflow — one recon agent per page — into `.audit/reference/<page-slug>/` using the repo tool (use `home`/`index` for the entry page):
+     ```bash
+     cd scripts/record-demos && npm install   # first run only — installs Playwright + Chromium
+     node scrape-ref.mjs "<page-url>" "../../templates/premium/<provider>/<project-name>/.audit/reference/<page-slug>"
+     ```
+     This writes `screenshot.png`, `page.html`, `outline.json`, `source.css` (all rules incl. `:hover`/`@keyframes`/transitions/`@media`), `sources.json`, and auto-captured `states/` hover pairs.
+   - **Capture EVERY interaction, not just hover.** For each original page, drive headless Playwright yourself and record — via the before/after-DOM-diff technique — hover (cards/buttons/links/nav), click/open (modals, dialogs, dropdowns, popovers, tooltips, accordions, tabs, "show more"/filters, hamburger/mobile menus, theme/dark-mode toggles, carousels, media controls), and scroll behavior (sticky/shrinking headers, scroll reveals, parallax, progress bars, lazy load). Write each page's `states/interactions.json` (trigger selector + observed delta + screenshots).
+   - **Capture responsiveness explicitly.** For each page, screenshot the original at **mobile (~390px), tablet (~768px), and desktop (~1280px)** widths into `states/responsive/` — these are the ground truth for the responsiveness check.
+   - **Capture both themes.** If the original has light and dark mode (toggle or `prefers-color-scheme`), capture each into `states/theme-light.png` / `states/theme-dark.png`.
+
+4. **Re-capture the CLONE the same way, apples-to-apples.** Boot the clone locally (static server / `record-one.sh`'s server / `python3 -m http.server`). Run the **same** recon tool, interaction replay, responsive screenshots, and theme captures against each clone page into `.audit/clone/<page-slug>/`:
+   ```bash
+   node scrape-ref.mjs "http://localhost:<port>/<page>.html" "../../templates/premium/<provider>/<project-name>/.audit/clone/<page-slug>"
+   ```
+   Replay the original's `interactions.json` against the clone (click/open/scroll each) and capture the clone's resulting states the same way, so opened states diff one-to-one.
+
+5. **Vision-judge diff — what's missing or wrong.** Dispatch a vision-judge sub-agent (one per page, in parallel) that reads reference vs clone for that page and returns a structured, ordered findings list. It must check, explicitly, all of:
+   - **Pages present** — every original page exists in the clone (flag missing/extra pages; missing pages are a top-priority fix).
+   - **Styles** — palette/hex, fonts & weights, type scale, spacing, radii, shadows, easings (from `outline.json` + `source.css`).
+   - **Responsiveness** — clone matches the original at mobile/tablet/desktop (from `states/responsive/`); flag layout breaks, overflow, unresponsive sections, or copied viewport-toggle chrome.
+   - **Buttons & states** — every button/link/nav `:hover`/`:focus`/active styling and transitions (from `states/` rest-vs-hover pairs + `source.css`).
+   - **Behavior** — every interaction in `interactions.json`: modals, dialogs, dropdowns, popovers, tooltips, accordions, tabs, menus, toggles, carousels, scroll reveals — opened state matches the original's delta.
+   - **Light/dark mode** — both themes render faithfully, the toggle works (icon, transition, `localStorage`, no-flash boot) when the original has one, and no hardcoded colors fail to switch.
+   The verdict per page is faithful / not-faithful plus the concrete fix list (spacing off by X, wrong hex, wrong font/weight, missing hover, opened-state mismatch, missing entrance animation, missing section/page, responsive break at Npx, theme not switching).
+
+6. **FIX every confirmed gap — self-correcting vision loop, cap 5 iterations/page, all pages in parallel.** This is the cloner's step 8 loop applied as repair: apply the judge's fixes to the clone's HTML/CSS/JS — porting exact `:hover`/`@keyframes`/transitions from the original `source.css` and behavior from the original's fetched JS, never guessing — then re-boot, re-run the recon tool + interaction replay + responsive/theme captures against the clone, re-judge, and repeat until the judge calls every page faithful or 5 iterations hit. Build any missing page from its original `.audit/reference/<slug>/` artifacts, reusing the shared tokens/chrome. Keep all colors on light/dark theme tokens; vendor any newly needed assets locally under `assets/`. If a page caps without converging, record the residual diffs for the report. Motion a still can't show is verified by confirming ported JS/CSS matches the original's keyframes/triggers.
+
+7. **If nothing drifted, stop cleanly.** If the judge found the clone already faithful on every page (no fixes applied), do **not** open an empty PR or re-record. Tear down the worktree and report the project as "audited, already faithful" with the evidence. (In an `all` sweep, just skip it and move on.)
+
+8. **Re-record the demo + poster (only when something changed).**
+   - `cd scripts/record-demos && ./record-one.sh ../../templates/premium/<provider>/<project-name>` → confirm a fresh non-empty `demo.mp4` (`ffprobe`); fix and re-run on failure. Multi-page clones record the entry page — expected.
+   - `node scripts/generate-posters/generate-posters.mjs` → confirm `poster.jpg` and the project's `posters.json` entry are regenerated.
+
+9. **Reconcile READMEs.** The audit doesn't add a project, but if you created a missing page or changed structure, make sure the project's own `README.md` still embeds the clickable demo thumbnail (`[![Watch Demo](./poster.jpg)](./demo.mp4)`) and that root `## Projects (N)` / `templates` `<summary>` / `templates/README.md` counts still equal on-disk folder counts (count `templates/premium/*/*/`). Fix drift; never blind-increment.
+
+10. **Consistency sweep, merge main, finalize.** Confirm every audited project still has `prompt.md`/`demo.mp4`/`poster.jpg` + `posters.json` entry; no phantom paths. Then `git fetch origin main && git merge origin/main`, resolve conflicts (re-reconcile counts if README/posters.json changed), re-verify.
+
+11. **Commit, PR, auto-merge.** Run `make format` from the repo root, then `git add -u` to stage reformatted files. Commit the clone fixes + `.audit/` evidence + re-recorded `demo.mp4` + regenerated `poster.jpg` + `posters.json` + any README updates (e.g. `Audit fixes for premium/<provider>/<project-name>`). `gh pr create` against `main`. If checks are configured, `gh pr checks <n> --watch` first, then `gh pr merge <n> --merge --delete-branch` (auto-merge). Then `git worktree remove .claude/worktrees/audit-<project-name>`, `git worktree prune`, delete the local branch if it lingers.
+
+12. **Push the updated demo to Cloudinary with `--force`.** A re-recorded `demo.mp4` overwrites a demo whose Cloudinary asset already exists — the automatic push-to-main `upload-video-demos` run uploads **new** assets only and would skip the changed one, so you must force it. After the PR is merged to main (so the new `demo.mp4` is on `origin/main`):
+   - Preferred — dispatch the workflow with force:
+     ```bash
+     gh workflow run upload-video-demos.yml -f force=true
+     ```
+     Then watch it and confirm success:
+     ```bash
+     gh run list --workflow=upload-video-demos.yml -L 1
+     gh run watch <run-id> --exit-status
+     ```
+   - Fallback (if the workflow can't be dispatched, e.g. no Actions perms) — run it locally with the same flag, requires the `CLOUDINARY_CLOUD_NAME`/`CLOUDINARY_API_KEY`/`CLOUDINARY_API_SECRET` env vars:
+     ```bash
+     cd scripts/upload-demos && npm ci || npm install && node index.js --force
+     ```
+   - **Verify it actually worked** — the run/job summary (or local output) must show the changed demo re-uploaded (not skipped). If the upload reports the asset unchanged/skipped, you didn't force it — re-run with `--force`. Report the run URL (or local result) and that the updated demo is live.
+
+# Hard rules
+
+- **Audit against the real original** — re-scrape the live `REFERENCE:` URL every run; never judge from the old `.reference/` snapshot alone (the source may have changed). Original = ground truth.
+- **Audit EVERY page, style, breakpoint, button, interaction, and theme** — the six checks in step 5 are all mandatory; a clone is only "faithful" when all pass. Missing pages and broken responsiveness are top-priority fixes.
+- **Fix, don't just report** — every confirmed gap is repaired via the vision loop (cap 5/page), then re-verified. Report-only is not the job.
+- **Re-record after fixing** — any change to a clone means a fresh `demo.mp4` (via `record-one.sh` only) + regenerated `poster.jpg`/`posters.json` (via `generate-posters.mjs` only). Never hand-roll these.
+- **Force the Cloudinary push** — a re-recorded demo's asset already exists, so the post-merge upload must use `--force` (`gh workflow run upload-video-demos.yml -f force=true`, or local `node index.js --force`), and you must verify the upload succeeded — not silently skipped.
+- **No change → no PR, no re-record, no upload** — if the clone is already faithful, tear down and report; never open an empty PR or force a needless upload.
+- **Clone the template, never the preview host's chrome** — ignore the wrapping toolbar / viewport toggles; judge native responsiveness, not copied viewport controls.
+- **Parallelize via Workflows** — multi-project sweeps, per-page recon, and per-page vision loops fan out concurrently; they're independent.
+- **CLI/headless only** — all capture/hover/click/scroll is headless Playwright / curl / node. Show evidence from real command output, never "it should work".
+- **Run `make format` before every commit** — from the repo root, then `git add -u`.
+- README counts derived from on-disk folder counts, never blind increments; root and `templates/` READMEs kept in sync if structure changed.
+
+# Final report
+
+For each audited project include: the project path and its `REFERENCE:` URL; the original page list discovered vs the clone's pages (missing/extra called out); per check (pages, styles, responsiveness, buttons/states, behavior, light/dark) what drifted and what you fixed; per page how many vision-loop iterations ran and whether it converged or capped (with residual diffs if capped); whether anything changed at all (if not, "already faithful — no PR"); confirmation the demo/poster/posters.json were re-recorded when changed; the PR URL and that it merged; and the `upload-video-demos` run URL (or local result) confirming the updated demo was force-pushed to Cloudinary and verified live. For an `all` sweep, give this per project plus a summary line of how many drifted/were fixed vs already faithful.

--- a/project-dates.json
+++ b/project-dates.json
@@ -1,1394 +1,1394 @@
 [
-  {
-    "project": "vellum-atelier-h33",
-    "lastUpdated": "2026-06-25T14:38:34+05:30"
-  },
-  {
-    "project": "premium",
-    "lastUpdated": "2026-06-25T14:38:34+05:30"
-  },
-  {
-    "project": "sidi-bou-said-3d-walk",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "bags-editorial-collage",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "bloom-nested-squares",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "container-scroll-animation",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dot-nokia-typing-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "linkflow-boomerang-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "mainframe-scrub-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "microvisuals-boomerang-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "moneta-key-preloader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "pallet-ross-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "qclay-hexagon-loader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "scroll-expansion-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "animated-dots-rain",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "animated-hud-targeting-ui",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aurora-sign-up",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "background-paths-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "core-features-gradient-cards",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "crimson-mill-supply-card-h61",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "gradient-bars-background",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "gradient-dots-background",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "interactive-3d-spline-scene",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumen-aurora-vcard-h62",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "nexto-404-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "scanner-card-stream",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sixsense-reference-finder",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "spatial-product-showcase",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "terminal-cli-control-deck",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aethera-cinematic-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ai-builder-dark-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "altitude-index-h38",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "animated-text-rotate-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "bloom-liquid-glass-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cinematic-stream-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "codenest-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "convix-pr-agency-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "datacore-video-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "designpro-video-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "digital-epoch-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "equilibrium-liquid-glass-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "fearless-vision-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "helix-vault-h55",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ironclad-password-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "mainframe-hero-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "monocrit-studio-h27",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "nexora-automation-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "noctis-cinematic-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "particle-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "power-ai-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "prisma-noir-h52",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "rivr-defi-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "securify-data-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sentinel-ai-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "shape-landing-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "skyelite-jet-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "smart-prosthetics-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "stellar-ai-landing-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "synex-wealth-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "taskly-liquid-glass-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "toonhub-figurine-carousel",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "transform-data-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vanguard-hero-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vaultshield-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "velorah-hero-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdant-advisory-h10",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "wanderful-cinematic-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "woven-light-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "xero-encryption-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aegis-console-h39",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "almond-hours-h65",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "amber-foundry-h9",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "amberhaus-pet-atelier-h31",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "archway-summit-h21",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "asme-hero-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "asme-liquid-glass-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "astral-veil-h6",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "atelier-noir-h7",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "atelier-press-h51",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aura-email-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "auric-clinic-glow-h37",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "auroracast-hls-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "axion-studio-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "axis-quotient-h30",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "azimuth-realty-engine-h36",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "carbon-bloom-h95",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cartwright-relocation-h47",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cerulean-precision-collective-h67",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "citron-atlas-h79",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "claywell-solene-h5",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cobalt-repairworks-h78",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "concrete-bazaar-h87",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "crimson-cut-studio-h72",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "design-rocket-email",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dhara-heritage-edit-h88",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dot-daily-calm-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ember-quietude-h26",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "evergreen-ledger-h94",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "fernhollow-pet-wellness-h68",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "forma-video-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "freightleaf-clean-haul-h80",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "graft-modular-h93",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "gridframe-precision-h74",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "gridwright-h48",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "grove-kitchen-fresh-h70",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "halcyon-mesh-h56",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "harbour-hearth-h64",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "hearthwell-homeware-h71",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "helix-strata-h76",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ink-vermilion-personal-brand-h23",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "kairos-academy-h0",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lantern-broth-midnight-ramen-h8",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lantern-loft-tutoring-h1",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumen-grove-h63",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumen-launch-h44",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumen-vector-h92",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumina-maternite-h2",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "mentality-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "meridian-grid-systems-h81",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "meridian-precision-clinic-h35",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "mindloop-mono-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "monolith-grid-atelier-h59",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "neuralyn-dark-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "nhm-paleontology-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "noctis-aurum-h69",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "obsidian-lacquer-h57",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "obsidian-meridian-h85",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ochre-stone-studio-h11",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "orbis-nft-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "orbital-frequency-summit-h22",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "paper-circuit-agentic-saas-h16",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "prisma-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "riso-rebel-fest-h20",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "saaj-heritage-bazaar-h90",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sencha-atelier-h12",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sentinel-meridian-h77",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "slate-stone-architectural-h73",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "slow-roast-atelier-h84",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "snip-and-snout-grooming-h18",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "solace-wellness-grid-h13",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "space-voyage-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "spectral-orbit-novascale-h17",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "synergeus-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "terra-craft-editorial-h58",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "terra-siena-atelier-h14",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "tide-table-h82",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "usd-halo-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vantix-precision-medicine-h34",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vellum-apothecary-archive-h32",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "velvet-vellum-agency-h4",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdant-atelier-h40",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdant-pledge-bento-h49",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdant-salon-h91",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdant-spine-clinic-h66",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdigris-trail-h50",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vermillion-cram-h3",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vermillion-table-h83",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "viktor-oddy-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "voltaic-grid-advisory-h75",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "voltframe-dev-h29",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "voltic-showroom-h89",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "voltline-automation-h60",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "wayfare-expedition-journal-h86",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "circuit-ledger-h15",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cobalt-bento-folio-h43",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "crimson-press-kit-h25",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "electric-volt-folio-h45",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "inkpress-atelier-h46",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "jack-3d-portfolio",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumen-folio-h19",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "meridian-drafthouse-h54",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "michael-smith-portfolio",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "monogram-terminal-h42",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "nocturne-bento-h28",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "solstice-craft-studio-h41",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "voltline-resume-h53",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "voltmark-engineer-terminal-h24",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "abstract-glassy-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aether-flow-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ai-input-wave-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "animated-shader-background",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "animated-shader-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "anomalous-matter-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "atc-tunnel-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aura-core-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aurora-borealis-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "blue-meshy-shader-lab",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "blueprint-ascii-grid-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cathedral-raymarch-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "celestial-bloom-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "celestial-ink-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "celestial-matrix-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "celestial-matrix-terminal",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "celestial-sphere-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cosmic-plasma-web",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "crystal-voronoi-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "crystalline-cube-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cybernetic-grid-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "digital-glitch-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "digital-petals-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dithering-shader-lab",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dithering-sphere-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dithering-swirl-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dotted-surface-waves",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "dynamic-waveform-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "electric-waves-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "endless-pursuit-shader-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "exoplanet-survey-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "flowing-waves-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "fluid-swirl-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "galactic-spiral-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "gaming-vibe-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "generative-mountain-scene",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "glsl-hills-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "grain-gradient-corners-lab",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "grainy-gradient-ripple-card",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "hero-button-expandable",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "hero-dithering-card",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "hero-futuristic-webgpu",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "hex-shield-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "hive-noise-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "horizon-strata-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "interactive-flux-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "launch-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "liquid-crystal-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "liquid-metal-foundry",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "living-nebula-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "mesh-gradient-shader-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "molten-core-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "morphing-light-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "moving-circles-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "novatrix-gradient-mesh",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "old-television-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "paper-shader-resume-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "paper-shaders-control-deck",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "paper-shaders-hero-lab",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "phosphor-30-shader-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "radial-aperture-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "radial-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "realistic-fog-background",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sdf-dreamscape-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "shader-animation-integration",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "shader-flow-field-rings",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "shader-lines-showcase",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "shader-plasma-grid-background",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "shader-spectral-clock",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sickui-waitlist-mesh-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "simplex-dithering-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "spooky-smoke-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "starship-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "thermal-shader-imaging",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vhs-noise-distortion-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vitruvian-ascii-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "volumetric-beams-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "warp-checks-background-lab",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "warp-dithering-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "warp-drive-shader-bridge",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "warp-shader-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "waves-shader-oscilloscope",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "webgl-flowing-gradient-shader",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "webgl-rgb-shift-shader-hero",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "atelier-archive-quiet-luxury",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aurum-neural-ai-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "browser-core-devtools-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "clinical-luxury-conversion",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cyber-serif-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "disruptor-brutalist-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "editorial-naturalism-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "emerald-glass-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "enterprise-admin-saas-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "flux-editorial-saas-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "forest-sage-organic-store",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "gen-z-neobrutalist-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "heavyweight-brutalist-store",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "kinetic-orange-brutalist-agency",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumina-neobrutalist-saas-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumina-portfolio-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "midnight-editorial-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "neon-velocity-style-guide",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "obsidian-elite-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "organic-intelligence-wave",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "raw-form-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "realmagic-ticker-scroll",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "red-sun-editorial-template",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "season-04-brutalist-store",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "softly-wellness",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "stacking-cards-portfolio",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "sticky-content-switch",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "super-design-industrial-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "super-travel-luxury-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-architectural-type",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-cinematic-agency",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-crimson-craft",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-design-on-reality",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-editorial-grid",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-editorial-manifesto",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-invite-waitlist",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-midnight-editorial",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-modern-atmospheric",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-modern-obsidian",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-neo-brutalist-acid",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-obsidian-lime",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-studio-editorial",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "superdesign-technical-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "synapse-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "terroir-tasting-room",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vertical-clip-text-slide",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "academia-classical-showcase",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "ai-budget-tracking-landing-page-velara-al",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aperture-minimalist-dark",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "art-deco-gatsby-showcase",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "aurora-flow-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "bauhaus-form-follows-function",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "bitcoin-defi-aurum",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "bold-typography-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "botanical-organic-serif",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "clay-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "copy-machine-pixel-perfect",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "copy-machine-setup",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "corporate-trust-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "cyberpunk-glitch-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "finsyc-finance-landing",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "flatline-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "handcraft-paper-ui",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "industrial-skeuomorphism",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "kinetic-typography-poster",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumen-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lumina-minimalist-modern",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "luxury-editorial-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "material-you-showcase",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "maximalism-dopamine-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "neo-brutalism-loud-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "neumorphism-soft-ui",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "newsprint-editorial-press",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "playful-geometric-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "retro-90s-nostalgia-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "scaffold-ready-splash",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "serif-editorial-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "swiss-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "vaporwave-outrun-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "verdant-organic-design-system",
-    "lastUpdated": "2026-06-22T11:17:32+05:30"
-  },
-  {
-    "project": "lovable-webgl-hero",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  },
-  {
-    "project": "apex-scroll-hero",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  },
-  {
-    "project": "kubric-hero-landing",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  },
-  {
-    "project": "groundai-landing",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  },
-  {
-    "project": "pelmatech-health-companion",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  },
-  {
-    "project": "valmax-photography-landing",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  },
-  {
-    "project": "superdesign-red-noir-landing",
-    "lastUpdated": "2026-06-21T17:49:14+05:30"
-  }
+	{
+		"project": "vellum-atelier-h33",
+		"lastUpdated": "2026-06-25T14:38:34+05:30"
+	},
+	{
+		"project": "premium",
+		"lastUpdated": "2026-06-25T14:38:34+05:30"
+	},
+	{
+		"project": "sidi-bou-said-3d-walk",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "bags-editorial-collage",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "bloom-nested-squares",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "container-scroll-animation",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dot-nokia-typing-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "linkflow-boomerang-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "mainframe-scrub-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "microvisuals-boomerang-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "moneta-key-preloader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "pallet-ross-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "qclay-hexagon-loader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "scroll-expansion-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "animated-dots-rain",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "animated-hud-targeting-ui",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aurora-sign-up",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "background-paths-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "core-features-gradient-cards",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "crimson-mill-supply-card-h61",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "gradient-bars-background",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "gradient-dots-background",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "interactive-3d-spline-scene",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumen-aurora-vcard-h62",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "nexto-404-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "scanner-card-stream",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sixsense-reference-finder",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "spatial-product-showcase",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "terminal-cli-control-deck",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aethera-cinematic-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ai-builder-dark-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "altitude-index-h38",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "animated-text-rotate-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "bloom-liquid-glass-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cinematic-stream-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "codenest-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "convix-pr-agency-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "datacore-video-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "designpro-video-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "digital-epoch-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "equilibrium-liquid-glass-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "fearless-vision-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "helix-vault-h55",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ironclad-password-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "mainframe-hero-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "monocrit-studio-h27",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "nexora-automation-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "noctis-cinematic-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "particle-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "power-ai-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "prisma-noir-h52",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "rivr-defi-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "securify-data-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sentinel-ai-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "shape-landing-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "skyelite-jet-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "smart-prosthetics-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "stellar-ai-landing-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "synex-wealth-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "taskly-liquid-glass-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "toonhub-figurine-carousel",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "transform-data-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vanguard-hero-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vaultshield-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "velorah-hero-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdant-advisory-h10",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "wanderful-cinematic-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "woven-light-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "xero-encryption-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aegis-console-h39",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "almond-hours-h65",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "amber-foundry-h9",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "amberhaus-pet-atelier-h31",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "archway-summit-h21",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "asme-hero-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "asme-liquid-glass-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "astral-veil-h6",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "atelier-noir-h7",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "atelier-press-h51",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aura-email-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "auric-clinic-glow-h37",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "auroracast-hls-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "axion-studio-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "axis-quotient-h30",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "azimuth-realty-engine-h36",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "carbon-bloom-h95",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cartwright-relocation-h47",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cerulean-precision-collective-h67",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "citron-atlas-h79",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "claywell-solene-h5",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cobalt-repairworks-h78",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "concrete-bazaar-h87",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "crimson-cut-studio-h72",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "design-rocket-email",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dhara-heritage-edit-h88",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dot-daily-calm-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ember-quietude-h26",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "evergreen-ledger-h94",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "fernhollow-pet-wellness-h68",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "forma-video-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "freightleaf-clean-haul-h80",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "graft-modular-h93",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "gridframe-precision-h74",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "gridwright-h48",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "grove-kitchen-fresh-h70",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "halcyon-mesh-h56",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "harbour-hearth-h64",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "hearthwell-homeware-h71",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "helix-strata-h76",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ink-vermilion-personal-brand-h23",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "kairos-academy-h0",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lantern-broth-midnight-ramen-h8",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lantern-loft-tutoring-h1",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumen-grove-h63",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumen-launch-h44",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumen-vector-h92",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumina-maternite-h2",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "mentality-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "meridian-grid-systems-h81",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "meridian-precision-clinic-h35",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "mindloop-mono-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "monolith-grid-atelier-h59",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "neuralyn-dark-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "nhm-paleontology-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "noctis-aurum-h69",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "obsidian-lacquer-h57",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "obsidian-meridian-h85",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ochre-stone-studio-h11",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "orbis-nft-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "orbital-frequency-summit-h22",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "paper-circuit-agentic-saas-h16",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "prisma-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "riso-rebel-fest-h20",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "saaj-heritage-bazaar-h90",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sencha-atelier-h12",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sentinel-meridian-h77",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "slate-stone-architectural-h73",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "slow-roast-atelier-h84",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "snip-and-snout-grooming-h18",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "solace-wellness-grid-h13",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "space-voyage-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "spectral-orbit-novascale-h17",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "synergeus-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "terra-craft-editorial-h58",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "terra-siena-atelier-h14",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "tide-table-h82",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "usd-halo-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vantix-precision-medicine-h34",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vellum-apothecary-archive-h32",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "velvet-vellum-agency-h4",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdant-atelier-h40",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdant-pledge-bento-h49",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdant-salon-h91",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdant-spine-clinic-h66",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdigris-trail-h50",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vermillion-cram-h3",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vermillion-table-h83",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "viktor-oddy-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "voltaic-grid-advisory-h75",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "voltframe-dev-h29",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "voltic-showroom-h89",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "voltline-automation-h60",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "wayfare-expedition-journal-h86",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "circuit-ledger-h15",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cobalt-bento-folio-h43",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "crimson-press-kit-h25",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "electric-volt-folio-h45",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "inkpress-atelier-h46",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "jack-3d-portfolio",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumen-folio-h19",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "meridian-drafthouse-h54",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "michael-smith-portfolio",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "monogram-terminal-h42",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "nocturne-bento-h28",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "solstice-craft-studio-h41",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "voltline-resume-h53",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "voltmark-engineer-terminal-h24",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "abstract-glassy-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aether-flow-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ai-input-wave-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "animated-shader-background",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "animated-shader-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "anomalous-matter-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "atc-tunnel-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aura-core-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aurora-borealis-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "blue-meshy-shader-lab",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "blueprint-ascii-grid-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cathedral-raymarch-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "celestial-bloom-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "celestial-ink-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "celestial-matrix-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "celestial-matrix-terminal",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "celestial-sphere-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cosmic-plasma-web",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "crystal-voronoi-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "crystalline-cube-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cybernetic-grid-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "digital-glitch-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "digital-petals-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dithering-shader-lab",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dithering-sphere-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dithering-swirl-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dotted-surface-waves",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "dynamic-waveform-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "electric-waves-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "endless-pursuit-shader-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "exoplanet-survey-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "flowing-waves-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "fluid-swirl-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "galactic-spiral-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "gaming-vibe-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "generative-mountain-scene",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "glsl-hills-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "grain-gradient-corners-lab",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "grainy-gradient-ripple-card",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "hero-button-expandable",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "hero-dithering-card",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "hero-futuristic-webgpu",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "hex-shield-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "hive-noise-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "horizon-strata-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "interactive-flux-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "launch-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "liquid-crystal-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "liquid-metal-foundry",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "living-nebula-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "mesh-gradient-shader-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "molten-core-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "morphing-light-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "moving-circles-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "novatrix-gradient-mesh",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "old-television-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "paper-shader-resume-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "paper-shaders-control-deck",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "paper-shaders-hero-lab",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "phosphor-30-shader-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "radial-aperture-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "radial-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "realistic-fog-background",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sdf-dreamscape-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "shader-animation-integration",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "shader-flow-field-rings",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "shader-lines-showcase",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "shader-plasma-grid-background",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "shader-spectral-clock",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sickui-waitlist-mesh-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "simplex-dithering-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "spooky-smoke-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "starship-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "thermal-shader-imaging",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vhs-noise-distortion-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vitruvian-ascii-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "volumetric-beams-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "warp-checks-background-lab",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "warp-dithering-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "warp-drive-shader-bridge",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "warp-shader-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "waves-shader-oscilloscope",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "webgl-flowing-gradient-shader",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "webgl-rgb-shift-shader-hero",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "atelier-archive-quiet-luxury",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aurum-neural-ai-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "browser-core-devtools-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "clinical-luxury-conversion",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cyber-serif-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "disruptor-brutalist-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "editorial-naturalism-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "emerald-glass-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "enterprise-admin-saas-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "flux-editorial-saas-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "forest-sage-organic-store",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "gen-z-neobrutalist-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "heavyweight-brutalist-store",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "kinetic-orange-brutalist-agency",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumina-neobrutalist-saas-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumina-portfolio-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "midnight-editorial-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "neon-velocity-style-guide",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "obsidian-elite-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "organic-intelligence-wave",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "raw-form-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "realmagic-ticker-scroll",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "red-sun-editorial-template",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "season-04-brutalist-store",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "softly-wellness",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "stacking-cards-portfolio",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "sticky-content-switch",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "super-design-industrial-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "super-travel-luxury-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-architectural-type",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-cinematic-agency",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-crimson-craft",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-design-on-reality",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-editorial-grid",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-editorial-manifesto",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-invite-waitlist",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-midnight-editorial",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-modern-atmospheric",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-modern-obsidian",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-neo-brutalist-acid",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-obsidian-lime",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-studio-editorial",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "superdesign-technical-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "synapse-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "terroir-tasting-room",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vertical-clip-text-slide",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "academia-classical-showcase",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "ai-budget-tracking-landing-page-velara-al",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aperture-minimalist-dark",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "art-deco-gatsby-showcase",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "aurora-flow-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "bauhaus-form-follows-function",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "bitcoin-defi-aurum",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "bold-typography-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "botanical-organic-serif",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "clay-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "copy-machine-pixel-perfect",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "copy-machine-setup",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "corporate-trust-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "cyberpunk-glitch-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "finsyc-finance-landing",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "flatline-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "handcraft-paper-ui",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "industrial-skeuomorphism",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "kinetic-typography-poster",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumen-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lumina-minimalist-modern",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "luxury-editorial-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "material-you-showcase",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "maximalism-dopamine-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "neo-brutalism-loud-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "neumorphism-soft-ui",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "newsprint-editorial-press",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "playful-geometric-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "retro-90s-nostalgia-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "scaffold-ready-splash",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "serif-editorial-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "swiss-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "vaporwave-outrun-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "verdant-organic-design-system",
+		"lastUpdated": "2026-06-22T11:17:32+05:30"
+	},
+	{
+		"project": "lovable-webgl-hero",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	},
+	{
+		"project": "apex-scroll-hero",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	},
+	{
+		"project": "kubric-hero-landing",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	},
+	{
+		"project": "groundai-landing",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	},
+	{
+		"project": "pelmatech-health-companion",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	},
+	{
+		"project": "valmax-photography-landing",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	},
+	{
+		"project": "superdesign-red-noir-landing",
+		"lastUpdated": "2026-06-21T17:49:14+05:30"
+	}
 ]


### PR DESCRIPTION
Adds a `template-auditor` subagent: the QA-and-repair counterpart to `template-cloner`.

Given an already-built premium clone under `templates/premium/<provider>/<project>/` (or `all` to sweep every clone), it:

- Re-scrapes the live original (`REFERENCE:` URL from `prompt.md`) and the local clone with the existing `scrape-ref.mjs` tooling — every page, full-page screenshots, computed-style outlines, raw `source.css`, headless interaction capture, responsive (mobile/tablet/desktop) and light/dark captures.
- Runs a vision-judge diff across pages present, styles, responsiveness, button/hover/focus states, interactive behavior (modals, dropdowns, accordions, tabs, carousels, scroll reveals), and light/dark mode.
- **Fixes** every confirmed gap in place via the cloner's self-correcting vision loop (cap 5 iterations/page), builds any missing page, then re-records `demo.mp4` + poster.
- Reconciles README counts, `make format` → commit → PR → auto-merge to main.
- On any change, force-pushes the re-recorded demo to Cloudinary by dispatching the `upload-video-demos` workflow with `force=true` (the auto push-to-main run only uploads new assets and would skip a changed one), and verifies the upload succeeded.
- If nothing drifted: no PR, no re-record, no upload — reports 'already faithful'.

No-op single-file addition (plus the repo's standard `make format` normalization from the pre-commit hook).