### PR TITLE
Fix incorrect template count

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Projects are grouped by what they are. Each lives in its category folder (e.g. `
 </details>
 
 <details>
-<summary><b>Templates (205)</b></summary>
+<summary><b>Templates (242)</b></summary>
 
 | Project | Description | Stack |
 |---------|-------------|-------|

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,4 +1,4 @@
-# Templates (205)
+# Templates (242)
 
 
 | Project | Description | Stack |


### PR DESCRIPTION
A prior merge miscalculated the headline template count as 205. Restore it to the authoritative count from find templates -name prompt.md -not -path "*/.reference/*" | wc -l (242).