### PR TITLE
Exclude .reference/ recon dirs from Pages deploy artifact

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,10 +33,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Strip recon-only content from deploy
+        # .reference/ dirs hold scrape recon (screenshots, raw HTML/CSS) used
+        # only while building/auditing clones — never linked from the live
+        # site. They stay in git; just don't ship them to Pages.
+        run: find . -type d -name '.reference' -prune -exec rm -rf {} +
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
+          # Upload entire repository (minus .reference/, stripped above)
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
.reference/ directories hold scrape recon (screenshots, raw HTML/CSS captured
while cloning/auditing templates) — never linked from the live site. They stay
tracked in git, but the Pages workflow now strips them before uploading the
deploy artifact.

Note: this alone does not fix the 1GB Pages artifact limit — .reference/ is
only ~700MB of the ~5GB total. The rest is legitimate content (1.5GB demo
videos + ~2.7GB template assets) that would need a different hosting
strategy to fit under Pages' free-tier limit.