### PR TITLE
[codex] Add a visual browser for directory projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 Built mostly with **React, TypeScript, Vite, Tailwind CSS, Three.js, Framer Motion, and GSAP** (plus plenty of framework-free HTML/CSS/JS) — a reference collection of copy-pasteable, AI-generated front-end components and templates for anyone exploring what Claude can build on the web.
 
+## Local visual explorer
+
+The repository root includes a dependency-free visual catalog for browsing every project by poster, category, name, description, or technology. Start a local server from the repository root:
+
+```sh
+python3 -m http.server 4173
+```
+
+Then open [http://127.0.0.1:4173](http://127.0.0.1:4173). Project posters and demos are loaded on demand from the repository's GitHub media URLs, so the gallery works with a sparse checkout and does not download every video up front.
+
 **Categories:** [Hero sections](./hero-sections/) · [Landing pages](./landing-pages/) · [Shaders](./shaders/) · [UI design systems](./ui-design/) · [Components & UI](./components-ui/) · [Portfolios](./portfolios/) · [Animations & loaders](./animations-loaders/) · [3D & games](./3d-games/) · [Templates](./templates/)
 
 Each project folder includes the originating prompt as `prompt.md`, preserved alongside the generated code. Some prompts were inspired by or adapted from public prompt/design references, including [cnemri's gist](https://gist.github.com/cnemri/c917e11b3a6936823b509dcff53392aa), [motionsites.ai](https://motionsites.ai/), [lafys.com](https://lafys.com/), [designprompts.dev](https://www.designprompts.dev/), [21st.dev](https://21st.dev), [superdesign.dev](https://superdesign.dev/), and [landinghero.ai](https://landinghero.ai/).

--- a/app.js
+++ b/app.js
@@ -1,0 +1,447 @@
+const REPOSITORY_URL = "https://github.com/pulkitxm/claude-directory";
+const RAW_BASE_URL =
+	"https://raw.githubusercontent.com/pulkitxm/claude-directory/main";
+const PAGE_SIZE = 24;
+
+const CATEGORY_LABELS = {
+	"hero-sections": "Hero sections",
+	"landing-pages": "Landing pages",
+	"animations-loaders": "Animations & loaders",
+	"3d-games": "3D & games",
+	portfolios: "Portfolios",
+	"components-ui": "Components & UI",
+	"ui-design": "UI design",
+	shaders: "Shaders",
+	templates: "Templates",
+};
+
+const state = {
+	projects: [],
+	filtered: [],
+	category: "all",
+	query: "",
+	sort: "latest",
+	visible: PAGE_SIZE,
+};
+
+const elements = {
+	grid: document.querySelector("#project-grid"),
+	filters: document.querySelector("#category-filters"),
+	search: document.querySelector("#project-search"),
+	sort: document.querySelector("#project-sort"),
+	visibleCount: document.querySelector("#visible-count"),
+	resultsLabel: document.querySelector("#results-label"),
+	clearFilters: document.querySelector("#clear-filters"),
+	emptyState: document.querySelector("#empty-state"),
+	loadMoreWrap: document.querySelector("#load-more-wrap"),
+	loadMore: document.querySelector("#load-more"),
+	remainingCount: document.querySelector("#remaining-count"),
+	cardTemplate: document.querySelector("#project-card-template"),
+	projectCount: document.querySelector("#hero-project-count"),
+	categoryCount: document.querySelector("#hero-category-count"),
+	dialog: document.querySelector("#project-dialog"),
+	dialogClose: document.querySelector(".dialog-close"),
+	dialogVideo: document.querySelector("#dialog-video"),
+	videoLoading: document.querySelector("#video-loading"),
+	dialogCategory: document.querySelector("#dialog-category"),
+	dialogTitle: document.querySelector("#dialog-title"),
+	dialogPath: document.querySelector("#dialog-path"),
+	dialogDescription: document.querySelector("#dialog-description"),
+	dialogStack: document.querySelector("#dialog-stack"),
+	dialogDate: document.querySelector("#dialog-date"),
+	dialogSource: document.querySelector("#dialog-source"),
+	dialogPrompt: document.querySelector("#dialog-prompt"),
+};
+
+function encodePath(path) {
+	return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function displayTitle(name) {
+	const lastPart = name.split("/").at(-1);
+	return lastPart
+		.split("-")
+		.map((word) => {
+			if (/^(ai|ui|ux|3d|hls|saas|defi|nft|glsl|webgl)$/i.test(word)) {
+				return word.toUpperCase();
+			}
+			return word.charAt(0).toUpperCase() + word.slice(1);
+		})
+		.join(" ");
+}
+
+function decodeEntities(value) {
+	const parser = document.createElement("textarea");
+	parser.innerHTML = value;
+	return parser.value;
+}
+
+function formatDate(value, compact = false) {
+	if (!value) return "Date unknown";
+	const date = new Date(value);
+	if (Number.isNaN(date.valueOf())) return "Date unknown";
+	return new Intl.DateTimeFormat(
+		"en",
+		compact
+			? { month: "short", day: "numeric" }
+			: { year: "numeric", month: "short", day: "numeric" },
+	).format(date);
+}
+
+function parseProjects(readme, posters, dates) {
+	const dateMap = new Map();
+	for (const item of dates) {
+		dateMap.set(item.project, item.lastUpdated);
+	}
+
+	const projects = [];
+	const rowPattern =
+		/^\| \[([^\]]+)\]\(\.\/([^)]+)\/\) \| (.*?) \| (.*?) \|$/gm;
+
+	for (const match of readme.matchAll(rowPattern)) {
+		const [, name, path, rawDescription, rawStack] = match;
+		const category = path.split("/")[0];
+		const media = posters[path];
+		const description = decodeEntities(
+			rawDescription.replaceAll(/`([^`]+)`/g, "$1"),
+		);
+		const stack = decodeEntities(rawStack.replaceAll(/`([^`]+)`/g, "$1"));
+		const pathParts = path.split("/");
+		const updatedAt =
+			dateMap.get(path) ||
+			dateMap.get(name) ||
+			dateMap.get(pathParts.at(-1)) ||
+			null;
+
+		projects.push({
+			name,
+			title: displayTitle(name),
+			path,
+			category,
+			categoryLabel: CATEGORY_LABELS[category] || category,
+			description,
+			stack,
+			tags: stack
+				.split(",")
+				.map((tag) => tag.trim())
+				.filter(Boolean),
+			poster: media?.poster || null,
+			video: media?.video || null,
+			blurDataURL: media?.blurDataURL || "",
+			width: media?.width || 16,
+			height: media?.height || 10,
+			updatedAt,
+			timestamp: updatedAt ? new Date(updatedAt).valueOf() : 0,
+			searchText: `${name} ${path} ${description} ${stack}`.toLowerCase(),
+		});
+	}
+
+	return projects;
+}
+
+function renderFilters() {
+	const counts = new Map();
+	for (const project of state.projects) {
+		counts.set(project.category, (counts.get(project.category) || 0) + 1);
+	}
+
+	const categories = [
+		"all",
+		...Object.keys(CATEGORY_LABELS).filter((slug) => counts.has(slug)),
+	];
+	const fragment = document.createDocumentFragment();
+
+	for (const category of categories) {
+		const button = document.createElement("button");
+		const count =
+			category === "all" ? state.projects.length : counts.get(category);
+		button.type = "button";
+		button.className = "filter-button";
+		button.dataset.category = category;
+		button.setAttribute("aria-pressed", String(category === state.category));
+		button.append(
+			document.createTextNode(
+				category === "all" ? "All projects" : CATEGORY_LABELS[category],
+			),
+		);
+
+		const countElement = document.createElement("span");
+		countElement.textContent = String(count);
+		button.append(countElement);
+		fragment.append(button);
+	}
+
+	elements.filters.replaceChildren(fragment);
+}
+
+function makeCard(project, index) {
+	const node = elements.cardTemplate.content.cloneNode(true);
+	const article = node.querySelector(".project-card");
+	const button = node.querySelector(".card-open");
+	const imageWrap = node.querySelector(".card-image-wrap");
+	const image = node.querySelector("img");
+
+	button.dataset.path = project.path;
+	button.setAttribute("aria-label", `Preview ${project.title}`);
+	node.querySelector(".card-number").textContent = String(index + 1).padStart(
+		3,
+		"0",
+	);
+	node.querySelector(".card-category").textContent = project.categoryLabel;
+	node.querySelector(".card-title").textContent = project.title;
+	node.querySelector(".card-description").textContent = project.description;
+
+	if (project.poster) {
+		image.src = `${RAW_BASE_URL}/${encodePath(project.poster)}`;
+		image.alt = `Preview of ${project.title}`;
+		image.width = project.width;
+		image.height = project.height;
+		imageWrap.style.backgroundImage = project.blurDataURL
+			? `url("${project.blurDataURL}")`
+			: "";
+		image.addEventListener(
+			"error",
+			() => {
+				article.classList.add("image-unavailable");
+				image.alt = `${project.title} preview unavailable`;
+			},
+			{ once: true },
+		);
+	} else {
+		image.remove();
+	}
+
+	const tagContainer = node.querySelector(".card-tags");
+	for (const tag of project.tags.slice(0, 2)) {
+		const element = document.createElement("i");
+		element.textContent = tag;
+		tagContainer.append(element);
+	}
+
+	const date = node.querySelector("time");
+	date.textContent = formatDate(project.updatedAt, true);
+	if (project.updatedAt) date.dateTime = project.updatedAt;
+
+	return node;
+}
+
+function applyFilters() {
+	const terms = state.query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+
+	state.filtered = state.projects.filter((project) => {
+		const matchesCategory =
+			state.category === "all" || project.category === state.category;
+		const matchesSearch = terms.every((term) =>
+			project.searchText.includes(term),
+		);
+		return matchesCategory && matchesSearch;
+	});
+
+	state.filtered.sort((a, b) => {
+		if (state.sort === "name") return a.title.localeCompare(b.title);
+		if (state.sort === "category") {
+			return (
+				a.categoryLabel.localeCompare(b.categoryLabel) ||
+				a.title.localeCompare(b.title)
+			);
+		}
+		return b.timestamp - a.timestamp || a.title.localeCompare(b.title);
+	});
+
+	renderProjects();
+}
+
+function renderProjects() {
+	const visibleProjects = state.filtered.slice(0, state.visible);
+	const fragment = document.createDocumentFragment();
+
+	visibleProjects.forEach((project, index) => {
+		fragment.append(makeCard(project, index));
+	});
+	elements.grid.replaceChildren(fragment);
+	elements.grid.setAttribute("aria-busy", "false");
+
+	const total = state.filtered.length;
+	const remaining = Math.max(total - visibleProjects.length, 0);
+	elements.visibleCount.textContent = total.toLocaleString();
+	elements.resultsLabel.textContent = total === 1 ? "project" : "projects";
+	elements.emptyState.hidden = total !== 0;
+	elements.grid.hidden = total === 0;
+	elements.loadMoreWrap.hidden = remaining === 0;
+	elements.remainingCount.textContent = remaining
+		? `${remaining.toLocaleString()} remaining`
+		: "";
+	elements.clearFilters.hidden = state.category === "all" && !state.query;
+}
+
+function resetFilters() {
+	state.category = "all";
+	state.query = "";
+	state.visible = PAGE_SIZE;
+	elements.search.value = "";
+	for (const button of elements.filters.querySelectorAll(".filter-button")) {
+		button.setAttribute(
+			"aria-pressed",
+			String(button.dataset.category === "all"),
+		);
+	}
+	applyFilters();
+}
+
+function openProject(project) {
+	const encodedPath = encodePath(project.path);
+	const posterUrl = project.poster
+		? `${RAW_BASE_URL}/${encodePath(project.poster)}`
+		: "";
+	const videoUrl = project.video
+		? `${RAW_BASE_URL}/${encodePath(project.video)}`
+		: "";
+
+	elements.dialogCategory.textContent = project.categoryLabel;
+	elements.dialogTitle.textContent = project.title;
+	elements.dialogPath.textContent = project.path;
+	elements.dialogDescription.textContent = project.description;
+	elements.dialogStack.textContent = project.stack;
+	elements.dialogDate.textContent = formatDate(project.updatedAt);
+	elements.dialogSource.href = `${REPOSITORY_URL}/tree/main/${encodedPath}`;
+	elements.dialogPrompt.href = `${REPOSITORY_URL}/blob/main/${encodedPath}/prompt.md`;
+	elements.videoLoading.classList.remove("is-ready");
+	elements.videoLoading.style.backgroundImage = posterUrl
+		? `url("${posterUrl}")`
+		: "";
+	elements.dialogVideo.poster = posterUrl;
+
+	if (videoUrl) {
+		elements.dialogVideo.src = videoUrl;
+		elements.dialogVideo.load();
+		elements.dialogVideo.play().catch(() => {});
+	} else {
+		elements.videoLoading.querySelector("p").textContent =
+			"No recorded demo available";
+	}
+
+	elements.dialog.showModal();
+	document.body.classList.add("dialog-open");
+}
+
+function closeProject() {
+	elements.dialog.close();
+}
+
+function resetDialogMedia() {
+	document.body.classList.remove("dialog-open");
+	elements.dialogVideo.pause();
+	elements.dialogVideo.removeAttribute("src");
+	elements.dialogVideo.removeAttribute("poster");
+	elements.dialogVideo.load();
+	elements.videoLoading.classList.remove("is-ready");
+	elements.videoLoading.querySelector("p").textContent =
+		"Loading recorded demo…";
+}
+
+function bindEvents() {
+	let searchTimer;
+
+	elements.search.addEventListener("input", (event) => {
+		window.clearTimeout(searchTimer);
+		searchTimer = window.setTimeout(() => {
+			state.query = event.target.value;
+			state.visible = PAGE_SIZE;
+			applyFilters();
+		}, 120);
+	});
+
+	elements.sort.addEventListener("change", (event) => {
+		state.sort = event.target.value;
+		state.visible = PAGE_SIZE;
+		applyFilters();
+	});
+
+	elements.filters.addEventListener("click", (event) => {
+		const button = event.target.closest(".filter-button");
+		if (!button) return;
+		state.category = button.dataset.category;
+		state.visible = PAGE_SIZE;
+		for (const filter of elements.filters.querySelectorAll(".filter-button")) {
+			filter.setAttribute("aria-pressed", String(filter === button));
+		}
+		applyFilters();
+	});
+
+	elements.grid.addEventListener("click", (event) => {
+		const button = event.target.closest(".card-open");
+		if (!button) return;
+		const project = state.projects.find(
+			(item) => item.path === button.dataset.path,
+		);
+		if (project) openProject(project);
+	});
+
+	elements.loadMore.addEventListener("click", () => {
+		state.visible += PAGE_SIZE;
+		renderProjects();
+	});
+
+	elements.clearFilters.addEventListener("click", resetFilters);
+	document
+		.querySelector("[data-clear-filters]")
+		.addEventListener("click", resetFilters);
+	elements.dialogClose.addEventListener("click", closeProject);
+	elements.dialog.addEventListener("click", (event) => {
+		if (event.target === elements.dialog) closeProject();
+	});
+	elements.dialog.addEventListener("close", resetDialogMedia);
+	elements.dialogVideo.addEventListener("canplay", () => {
+		elements.videoLoading.classList.add("is-ready");
+	});
+
+	document.addEventListener("keydown", (event) => {
+		if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+			event.preventDefault();
+			elements.search.focus();
+			elements.search.select();
+		}
+	});
+}
+
+async function initialise() {
+	try {
+		const [readmeResponse, postersResponse, datesResponse] = await Promise.all([
+			fetch("README.md"),
+			fetch("posters.json"),
+			fetch("project-dates.json"),
+		]);
+
+		if (!readmeResponse.ok || !postersResponse.ok || !datesResponse.ok) {
+			throw new Error("One or more catalog files could not be loaded.");
+		}
+
+		const [readme, posters, dates] = await Promise.all([
+			readmeResponse.text(),
+			postersResponse.json(),
+			datesResponse.json(),
+		]);
+
+		state.projects = parseProjects(readme, posters, dates);
+		if (!state.projects.length)
+			throw new Error("No projects were found in README.md.");
+
+		elements.projectCount.textContent = state.projects.length.toLocaleString();
+		elements.categoryCount.textContent = String(
+			new Set(state.projects.map((item) => item.category)).size,
+		).padStart(2, "0");
+		renderFilters();
+		applyFilters();
+		bindEvents();
+	} catch (error) {
+		console.error(error);
+		elements.grid.setAttribute("aria-busy", "false");
+		elements.grid.innerHTML = `
+      <div class="error-state">
+        <p>The catalog could not be loaded. Run this page through a local web server instead of opening the file directly.</p>
+      </div>
+    `;
+	}
+}
+
+initialise();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Browse the Claude Directory's open-source collection of AI-generated UI experiments."
+    />
+    <title>Claude Directory — Visual Explorer</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#gallery">Skip to gallery</a>
+
+    <header class="site-header">
+      <a class="brand" href="#top" aria-label="Claude Directory home">
+        <span class="brand-mark" aria-hidden="true">C<span>/</span>D</span>
+        <span class="brand-copy">
+          <strong>Claude Directory</strong>
+          <small>Visual explorer</small>
+        </span>
+      </a>
+      <a
+        class="header-link"
+        href="https://github.com/pulkitxm/claude-directory"
+        target="_blank"
+        rel="noreferrer"
+      >
+        View repository
+        <span aria-hidden="true">↗</span>
+      </a>
+    </header>
+
+    <main id="top">
+      <section class="hero" aria-labelledby="page-title">
+        <div class="hero-copy">
+          <p class="eyebrow"><span></span> Open-source interface archive</p>
+          <h1 id="page-title">Find something<br />worth <em>building</em> from.</h1>
+          <p class="hero-intro">
+            Explore AI-generated landing pages, shaders, components, portfolios,
+            and experiments without digging through folders by hand.
+          </p>
+          <div class="hero-actions">
+            <a class="primary-action" href="#gallery">Browse the collection <span>↓</span></a>
+            <p><strong id="hero-project-count">550</strong> projects, each with source and a recorded demo.</p>
+          </div>
+        </div>
+
+        <div class="hero-visual" aria-hidden="true">
+          <div class="hero-orbit hero-orbit-one"></div>
+          <div class="hero-orbit hero-orbit-two"></div>
+          <div class="hero-monogram">CD</div>
+          <div class="hero-index">
+            <span>INDEX</span>
+            <strong id="hero-category-count">09</strong>
+            <small>CATEGORIES</small>
+          </div>
+        </div>
+      </section>
+
+      <section class="catalog" id="gallery" aria-labelledby="catalog-title">
+        <div class="catalog-heading">
+          <div>
+            <p class="section-number">01 / DIRECTORY</p>
+            <h2 id="catalog-title">Browse the work</h2>
+          </div>
+          <p>
+            Search by project, technology, or description. Open any card to watch
+            its demo and jump directly to the source.
+          </p>
+        </div>
+
+        <div class="catalog-controls">
+          <label class="search-control" for="project-search">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"></circle>
+              <path d="m20 20-4-4"></path>
+            </svg>
+            <span class="sr-only">Search projects</span>
+            <input
+              id="project-search"
+              type="search"
+              placeholder="Search names, stacks, or ideas..."
+              autocomplete="off"
+            />
+            <kbd>⌘ K</kbd>
+          </label>
+
+          <label class="sort-control" for="project-sort">
+            <span>Sort</span>
+            <select id="project-sort">
+              <option value="latest">Recently updated</option>
+              <option value="name">Name A–Z</option>
+              <option value="category">Category</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="category-filters" id="category-filters" aria-label="Filter by category"></div>
+
+        <div class="results-bar" aria-live="polite">
+          <p><strong id="visible-count">0</strong> <span id="results-label">projects</span></p>
+          <button id="clear-filters" type="button" hidden>Clear filters</button>
+        </div>
+
+        <div class="project-grid" id="project-grid" aria-busy="true">
+          <div class="loading-state">
+            <span></span><span></span><span></span>
+            <p>Reading the directory…</p>
+          </div>
+        </div>
+
+        <div class="empty-state" id="empty-state" hidden>
+          <p class="empty-mark">Ø</p>
+          <h3>No matching experiments</h3>
+          <p>Try a broader search or switch to another category.</p>
+          <button type="button" data-clear-filters>Reset the directory</button>
+        </div>
+
+        <div class="load-more-wrap" id="load-more-wrap" hidden>
+          <button class="load-more" id="load-more" type="button">
+            <span>Load more projects</span>
+            <small id="remaining-count"></small>
+          </button>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>Built as a visual index for the open-source Claude Directory.</p>
+      <p>Source projects belong to their respective contributors.</p>
+    </footer>
+
+    <dialog class="project-dialog" id="project-dialog" aria-labelledby="dialog-title">
+      <button class="dialog-close" type="button" aria-label="Close preview">×</button>
+      <div class="dialog-media">
+        <video id="dialog-video" controls muted loop playsinline></video>
+        <div class="video-loading" id="video-loading">
+          <span></span>
+          <p>Loading recorded demo…</p>
+        </div>
+      </div>
+      <div class="dialog-content">
+        <p class="dialog-category" id="dialog-category"></p>
+        <h2 id="dialog-title"></h2>
+        <p class="dialog-path" id="dialog-path"></p>
+        <p class="dialog-description" id="dialog-description"></p>
+        <div class="dialog-meta">
+          <div>
+            <span>STACK</span>
+            <p id="dialog-stack"></p>
+          </div>
+          <div>
+            <span>UPDATED</span>
+            <p id="dialog-date"></p>
+          </div>
+        </div>
+        <div class="dialog-actions">
+          <a id="dialog-source" href="#" target="_blank" rel="noreferrer">View source <span>↗</span></a>
+          <a id="dialog-prompt" href="#" target="_blank" rel="noreferrer">Read prompt <span>↗</span></a>
+        </div>
+      </div>
+    </dialog>
+
+    <template id="project-card-template">
+      <article class="project-card">
+        <button class="card-open" type="button">
+          <span class="card-media">
+            <span class="card-image-wrap">
+              <img alt="" loading="lazy" decoding="async" />
+            </span>
+            <span class="card-topline">
+              <span class="card-number"></span>
+              <span class="card-category"></span>
+            </span>
+            <span class="card-play"><span>▶</span> Play demo</span>
+          </span>
+          <span class="card-body">
+            <span class="card-title-row">
+              <span class="card-title"></span>
+              <span class="card-arrow">↗</span>
+            </span>
+            <span class="card-description"></span>
+            <span class="card-footer">
+              <span class="card-tags"></span>
+              <time></time>
+            </span>
+          </span>
+        </button>
+      </article>
+    </template>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1197 @@
+:root {
+	--ink: #10110f;
+	--paper: #f4f1e9;
+	--surface: #fbfaf6;
+	--line: rgba(16, 17, 15, 0.18);
+	--muted: #6b6d65;
+	--acid: #d8ff42;
+	--orange: #ff5c35;
+	--radius: 18px;
+	color-scheme: light;
+	font-family:
+		Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+		sans-serif;
+	font-synthesis: none;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html {
+	scroll-behavior: smooth;
+}
+
+body {
+	margin: 0;
+	background: var(--paper);
+	color: var(--ink);
+	min-width: 320px;
+}
+
+button,
+input,
+select {
+	font: inherit;
+}
+
+button,
+a {
+	-webkit-tap-highlight-color: transparent;
+}
+
+a {
+	color: inherit;
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.skip-link {
+	position: fixed;
+	z-index: 100;
+	top: 12px;
+	left: 12px;
+	padding: 10px 14px;
+	background: var(--acid);
+	transform: translateY(-160%);
+}
+
+.skip-link:focus {
+	transform: translateY(0);
+}
+
+.site-header {
+	min-height: 82px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 14px clamp(20px, 4vw, 64px);
+	border-bottom: 1px solid var(--line);
+}
+
+.brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 12px;
+	text-decoration: none;
+}
+
+.brand-mark {
+	width: 48px;
+	height: 48px;
+	display: grid;
+	place-items: center;
+	border: 1px solid var(--ink);
+	border-radius: 50%;
+	font-family: Georgia, serif;
+	font-size: 15px;
+	letter-spacing: -0.08em;
+}
+
+.brand-mark span {
+	color: var(--orange);
+}
+
+.brand-copy {
+	display: grid;
+	gap: 2px;
+}
+
+.brand-copy strong {
+	font-size: 14px;
+	line-height: 1;
+}
+
+.brand-copy small,
+.header-link {
+	color: var(--muted);
+	font-size: 11px;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+}
+
+.header-link {
+	display: inline-flex;
+	gap: 12px;
+	align-items: center;
+	text-underline-offset: 4px;
+}
+
+.header-link span {
+	color: var(--ink);
+	font-size: 16px;
+}
+
+.hero {
+	min-height: min(720px, calc(100vh - 82px));
+	display: grid;
+	grid-template-columns: minmax(0, 1.2fr) minmax(380px, 0.8fr);
+	padding: clamp(56px, 8vw, 110px) clamp(20px, 4vw, 64px) 58px;
+	border-bottom: 1px solid var(--line);
+	overflow: hidden;
+}
+
+.hero-copy {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	position: relative;
+	z-index: 1;
+}
+
+.eyebrow,
+.section-number {
+	margin: 0 0 24px;
+	color: var(--muted);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+}
+
+.eyebrow {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.eyebrow span {
+	width: 7px;
+	height: 7px;
+	background: var(--orange);
+	border-radius: 50%;
+	box-shadow: 0 0 0 5px rgba(255, 92, 53, 0.12);
+}
+
+.hero h1 {
+	margin: 0;
+	max-width: 940px;
+	font-size: clamp(54px, 7.4vw, 112px);
+	font-weight: 520;
+	letter-spacing: -0.075em;
+	line-height: 0.84;
+}
+
+.hero h1 em {
+	font-family: Georgia, "Times New Roman", serif;
+	font-weight: 400;
+	color: var(--orange);
+}
+
+.hero-intro {
+	max-width: 630px;
+	margin: 38px 0 0;
+	color: #484a45;
+	font-size: clamp(17px, 1.4vw, 21px);
+	line-height: 1.55;
+}
+
+.hero-actions {
+	display: flex;
+	align-items: center;
+	gap: 28px;
+	margin-top: 36px;
+}
+
+.primary-action {
+	min-height: 54px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 20px;
+	padding: 0 22px;
+	border-radius: 999px;
+	background: var(--ink);
+	color: white;
+	font-size: 13px;
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.primary-action span {
+	color: var(--acid);
+}
+
+.hero-actions p {
+	max-width: 230px;
+	margin: 0;
+	color: var(--muted);
+	font-size: 12px;
+	line-height: 1.5;
+}
+
+.hero-actions strong {
+	color: var(--ink);
+}
+
+.hero-visual {
+	position: relative;
+	min-height: 440px;
+	align-self: center;
+	display: grid;
+	place-items: center;
+}
+
+.hero-visual::before {
+	content: "";
+	position: absolute;
+	width: min(31vw, 460px);
+	aspect-ratio: 1;
+	border-radius: 50%;
+	background: var(--acid);
+	box-shadow: 28px 40px 80px rgba(34, 36, 25, 0.18);
+}
+
+.hero-orbit {
+	position: absolute;
+	z-index: 1;
+	border: 1px solid rgba(16, 17, 15, 0.65);
+	border-radius: 50%;
+}
+
+.hero-orbit-one {
+	width: min(37vw, 550px);
+	aspect-ratio: 1.55;
+	transform: rotate(-24deg);
+}
+
+.hero-orbit-two {
+	width: min(35vw, 520px);
+	aspect-ratio: 2.2;
+	transform: rotate(47deg);
+}
+
+.hero-monogram {
+	position: relative;
+	z-index: 2;
+	font-family: Georgia, serif;
+	font-size: clamp(82px, 10vw, 160px);
+	letter-spacing: -0.13em;
+	transform: translateX(-0.06em);
+}
+
+.hero-index {
+	position: absolute;
+	z-index: 3;
+	right: 0;
+	bottom: 0;
+	width: 138px;
+	min-height: 154px;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	padding: 16px;
+	background: var(--ink);
+	color: white;
+	border-radius: 4px;
+}
+
+.hero-index span,
+.hero-index small {
+	font-size: 9px;
+	font-weight: 700;
+	letter-spacing: 0.16em;
+}
+
+.hero-index strong {
+	color: var(--acid);
+	font-family: Georgia, serif;
+	font-size: 54px;
+	font-weight: 400;
+	line-height: 0.9;
+}
+
+.catalog {
+	padding: 96px clamp(20px, 4vw, 64px) 110px;
+}
+
+.catalog-heading {
+	display: grid;
+	grid-template-columns: 1fr minmax(280px, 470px);
+	gap: 50px;
+	align-items: end;
+	padding-bottom: 42px;
+}
+
+.catalog-heading h2 {
+	margin: 0;
+	font-family: Georgia, "Times New Roman", serif;
+	font-size: clamp(44px, 5.5vw, 76px);
+	font-weight: 400;
+	letter-spacing: -0.055em;
+}
+
+.catalog-heading > p {
+	margin: 0 0 5px;
+	color: var(--muted);
+	line-height: 1.65;
+}
+
+.catalog-controls {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 12px;
+	padding: 12px;
+	background: var(--ink);
+	border-radius: var(--radius);
+}
+
+.search-control {
+	min-height: 58px;
+	display: flex;
+	align-items: center;
+	gap: 13px;
+	padding: 0 18px;
+	background: #23241f;
+	border: 1px solid #3a3b35;
+	border-radius: 11px;
+	color: #aeb0a8;
+}
+
+.search-control:focus-within {
+	border-color: var(--acid);
+}
+
+.search-control svg {
+	width: 19px;
+	fill: none;
+	stroke: currentColor;
+	stroke-width: 1.7;
+}
+
+.search-control input {
+	min-width: 0;
+	width: 100%;
+	border: 0;
+	outline: 0;
+	background: transparent;
+	color: white;
+}
+
+.search-control input::placeholder {
+	color: #85877f;
+}
+
+.search-control kbd {
+	min-width: 38px;
+	padding: 5px 7px;
+	border: 1px solid #4a4b46;
+	border-radius: 5px;
+	color: #8f918a;
+	font-family: inherit;
+	font-size: 10px;
+	text-align: center;
+}
+
+.sort-control {
+	min-width: 220px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 0 10px 0 18px;
+	color: #94968f;
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+}
+
+.sort-control select {
+	min-height: 42px;
+	flex: 1;
+	border: 0;
+	border-radius: 8px;
+	outline: 0;
+	padding: 0 12px;
+	background: var(--paper);
+	color: var(--ink);
+	font-size: 12px;
+	font-weight: 650;
+}
+
+.category-filters {
+	display: flex;
+	gap: 8px;
+	overflow-x: auto;
+	scrollbar-width: none;
+	padding: 20px 0;
+	border-bottom: 1px solid var(--line);
+}
+
+.category-filters::-webkit-scrollbar {
+	display: none;
+}
+
+.filter-button {
+	flex: none;
+	display: inline-flex;
+	align-items: center;
+	gap: 9px;
+	min-height: 39px;
+	padding: 0 13px;
+	border: 1px solid var(--line);
+	border-radius: 999px;
+	background: transparent;
+	color: #454741;
+	cursor: pointer;
+	font-size: 12px;
+}
+
+.filter-button span {
+	color: #8d8f88;
+	font-size: 10px;
+}
+
+.filter-button:hover,
+.filter-button[aria-pressed="true"] {
+	background: var(--ink);
+	color: white;
+	border-color: var(--ink);
+}
+
+.filter-button[aria-pressed="true"] span {
+	color: var(--acid);
+}
+
+.results-bar {
+	min-height: 70px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.results-bar p {
+	margin: 0;
+	color: var(--muted);
+	font-size: 12px;
+	letter-spacing: 0.04em;
+}
+
+.results-bar strong {
+	color: var(--ink);
+	font-size: 15px;
+}
+
+.results-bar button {
+	border: 0;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	font-size: 12px;
+	text-decoration: underline;
+	text-underline-offset: 4px;
+}
+
+.project-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 34px 16px;
+}
+
+.project-card {
+	min-width: 0;
+}
+
+.card-open {
+	width: 100%;
+	display: block;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	text-align: left;
+}
+
+.card-media {
+	position: relative;
+	display: block;
+	aspect-ratio: 16 / 10;
+	overflow: hidden;
+	background: #d9d6cd;
+	border-radius: 12px;
+}
+
+.card-image-wrap,
+.card-image-wrap img {
+	width: 100%;
+	height: 100%;
+	display: block;
+}
+
+.card-image-wrap {
+	background-position: center;
+	background-size: cover;
+}
+
+.card-image-wrap::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(
+		to bottom,
+		rgba(0, 0, 0, 0.28),
+		transparent 35%,
+		rgba(0, 0, 0, 0.08)
+	);
+	pointer-events: none;
+}
+
+.card-image-wrap img {
+	object-fit: cover;
+	transition:
+		transform 500ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		filter 250ms ease;
+}
+
+.card-open:hover .card-image-wrap img,
+.card-open:focus-visible .card-image-wrap img {
+	transform: scale(1.035);
+}
+
+.card-topline {
+	position: absolute;
+	z-index: 2;
+	top: 14px;
+	left: 14px;
+	right: 14px;
+	display: flex;
+	justify-content: space-between;
+	color: white;
+	font-size: 9px;
+	font-weight: 750;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	text-shadow: 0 1px 10px rgba(0, 0, 0, 0.4);
+}
+
+.card-category {
+	padding: 6px 8px;
+	background: rgba(16, 17, 15, 0.72);
+	border: 1px solid rgba(255, 255, 255, 0.18);
+	border-radius: 999px;
+	backdrop-filter: blur(8px);
+}
+
+.card-play {
+	position: absolute;
+	z-index: 2;
+	left: 50%;
+	top: 50%;
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	padding: 8px 11px 8px 8px;
+	border-radius: 999px;
+	background: white;
+	color: var(--ink);
+	font-size: 10px;
+	font-weight: 750;
+	opacity: 0;
+	transform: translate(-50%, -35%);
+	transition:
+		opacity 180ms ease,
+		transform 180ms ease;
+}
+
+.card-play span {
+	width: 25px;
+	height: 25px;
+	display: grid;
+	place-items: center;
+	padding-left: 2px;
+	border-radius: 50%;
+	background: var(--acid);
+	font-size: 8px;
+}
+
+.card-open:hover .card-play,
+.card-open:focus-visible .card-play {
+	opacity: 1;
+	transform: translate(-50%, -50%);
+}
+
+.card-body {
+	display: block;
+	padding: 15px 2px 0;
+}
+
+.card-title-row {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 14px;
+}
+
+.card-title {
+	font-family: Georgia, "Times New Roman", serif;
+	font-size: clamp(20px, 1.65vw, 27px);
+	line-height: 1.04;
+	letter-spacing: -0.035em;
+}
+
+.card-arrow {
+	flex: none;
+	font-size: 17px;
+	transition: transform 180ms ease;
+}
+
+.card-open:hover .card-arrow,
+.card-open:focus-visible .card-arrow {
+	transform: translate(3px, -3px);
+}
+
+.card-description {
+	min-height: 2.9em;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
+	margin-top: 9px;
+	color: var(--muted);
+	font-size: 12px;
+	line-height: 1.45;
+}
+
+.card-footer {
+	min-height: 31px;
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 12px;
+	margin-top: 13px;
+	padding-top: 12px;
+	border-top: 1px solid var(--line);
+}
+
+.card-tags {
+	min-width: 0;
+	display: flex;
+	gap: 5px;
+	overflow: hidden;
+}
+
+.card-tags i {
+	flex: none;
+	padding: 4px 7px;
+	border-radius: 4px;
+	background: #e7e4db;
+	color: #565852;
+	font-style: normal;
+	font-size: 8px;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.card-footer time {
+	flex: none;
+	color: #8b8d85;
+	font-size: 9px;
+	text-transform: uppercase;
+}
+
+.load-more-wrap {
+	display: flex;
+	justify-content: center;
+	padding-top: 68px;
+}
+
+.load-more {
+	min-width: 260px;
+	min-height: 62px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	border: 1px solid var(--ink);
+	border-radius: 999px;
+	background: transparent;
+	cursor: pointer;
+	font-size: 13px;
+	font-weight: 700;
+}
+
+.load-more small {
+	color: var(--muted);
+}
+
+.load-more:hover {
+	background: var(--ink);
+	color: white;
+}
+
+.load-more:hover small {
+	color: var(--acid);
+}
+
+.empty-state {
+	padding: 90px 20px;
+	border: 1px dashed var(--line);
+	border-radius: var(--radius);
+	text-align: center;
+}
+
+.empty-mark {
+	margin: 0;
+	color: var(--orange);
+	font-family: Georgia, serif;
+	font-size: 70px;
+}
+
+.empty-state h3 {
+	margin: 8px 0;
+	font-family: Georgia, serif;
+	font-size: 30px;
+	font-weight: 400;
+}
+
+.empty-state > p:not(.empty-mark) {
+	color: var(--muted);
+}
+
+.empty-state button {
+	margin-top: 12px;
+	padding: 11px 16px;
+	border: 0;
+	border-radius: 999px;
+	background: var(--ink);
+	color: white;
+	cursor: pointer;
+}
+
+.loading-state,
+.error-state {
+	grid-column: 1 / -1;
+	min-height: 300px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 7px;
+	flex-wrap: wrap;
+	color: var(--muted);
+}
+
+.loading-state span {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--orange);
+	animation: pulse 900ms ease infinite alternate;
+}
+
+.loading-state span:nth-child(2) {
+	animation-delay: 150ms;
+}
+
+.loading-state span:nth-child(3) {
+	animation-delay: 300ms;
+}
+
+.loading-state p {
+	flex-basis: 100%;
+	margin: 8px 0;
+	text-align: center;
+}
+
+@keyframes pulse {
+	to {
+		opacity: 0.25;
+		transform: translateY(-4px);
+	}
+}
+
+.site-footer {
+	min-height: 92px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 20px;
+	padding: 20px clamp(20px, 4vw, 64px);
+	background: var(--ink);
+	color: #969890;
+	font-size: 11px;
+}
+
+.project-dialog {
+	width: min(1180px, calc(100vw - 40px));
+	max-height: calc(100vh - 40px);
+	padding: 0;
+	border: 0;
+	border-radius: 18px;
+	overflow: hidden;
+	background: var(--surface);
+	color: var(--ink);
+}
+
+.project-dialog[open] {
+	display: grid;
+	grid-template-columns: minmax(0, 1.48fr) minmax(330px, 0.72fr);
+}
+
+.project-dialog::backdrop {
+	background: rgba(12, 13, 11, 0.84);
+	backdrop-filter: blur(8px);
+}
+
+.dialog-close {
+	position: absolute;
+	z-index: 5;
+	top: 14px;
+	right: 14px;
+	width: 38px;
+	height: 38px;
+	display: grid;
+	place-items: center;
+	padding: 0 0 3px;
+	border: 0;
+	border-radius: 50%;
+	background: rgba(255, 255, 255, 0.9);
+	color: var(--ink);
+	cursor: pointer;
+	font-size: 25px;
+	line-height: 1;
+}
+
+.dialog-media {
+	position: relative;
+	min-height: 560px;
+	display: grid;
+	place-items: center;
+	overflow: hidden;
+	background: #171814;
+}
+
+.dialog-media video {
+	width: 100%;
+	height: 100%;
+	max-height: calc(100vh - 40px);
+	object-fit: contain;
+	position: relative;
+	z-index: 2;
+}
+
+.video-loading {
+	position: absolute;
+	inset: 0;
+	display: grid;
+	place-content: center;
+	justify-items: center;
+	gap: 13px;
+	background-position: center;
+	background-size: cover;
+	color: white;
+}
+
+.video-loading::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: rgba(10, 10, 9, 0.55);
+	backdrop-filter: blur(12px);
+}
+
+.video-loading > * {
+	position: relative;
+}
+
+.video-loading span {
+	width: 34px;
+	height: 34px;
+	border: 2px solid rgba(255, 255, 255, 0.24);
+	border-top-color: var(--acid);
+	border-radius: 50%;
+	animation: spin 800ms linear infinite;
+}
+
+.video-loading p {
+	margin: 0;
+	font-size: 11px;
+}
+
+.video-loading.is-ready {
+	display: none;
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.dialog-content {
+	max-height: calc(100vh - 40px);
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	padding: 54px 34px 34px;
+}
+
+.dialog-category {
+	margin: 0 0 20px;
+	color: var(--orange);
+	font-size: 10px;
+	font-weight: 800;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+}
+
+.dialog-content h2 {
+	margin: 0;
+	font-family: Georgia, serif;
+	font-size: clamp(38px, 4vw, 58px);
+	font-weight: 400;
+	letter-spacing: -0.055em;
+	line-height: 0.95;
+}
+
+.dialog-path {
+	margin: 13px 0 0;
+	color: #90928b;
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	font-size: 9px;
+	word-break: break-all;
+}
+
+.dialog-description {
+	margin: 30px 0;
+	color: #53554f;
+	font-size: 13px;
+	line-height: 1.65;
+}
+
+.dialog-meta {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 18px;
+	margin-top: auto;
+	padding: 20px 0;
+	border-top: 1px solid var(--line);
+	border-bottom: 1px solid var(--line);
+}
+
+.dialog-meta span {
+	color: #92948d;
+	font-size: 8px;
+	font-weight: 800;
+	letter-spacing: 0.14em;
+}
+
+.dialog-meta p {
+	margin: 7px 0 0;
+	font-size: 11px;
+	line-height: 1.45;
+}
+
+.dialog-actions {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 8px;
+	margin-top: 22px;
+}
+
+.dialog-actions a {
+	min-height: 48px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 14px;
+	border: 1px solid var(--ink);
+	border-radius: 8px;
+	font-size: 11px;
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.dialog-actions a:first-child {
+	background: var(--ink);
+	color: white;
+}
+
+.dialog-actions a:first-child span {
+	color: var(--acid);
+}
+
+body.dialog-open {
+	overflow: hidden;
+}
+
+@media (max-width: 1000px) {
+	.hero {
+		grid-template-columns: 1fr minmax(300px, 0.5fr);
+	}
+
+	.hero-visual::before {
+		width: 310px;
+	}
+
+	.hero-orbit-one,
+	.hero-orbit-two {
+		width: 370px;
+	}
+
+	.project-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.project-dialog[open] {
+		grid-template-columns: 1.25fr 0.75fr;
+	}
+}
+
+@media (max-width: 760px) {
+	.site-header {
+		min-height: 72px;
+	}
+
+	.brand-mark {
+		width: 42px;
+		height: 42px;
+	}
+
+	.header-link {
+		font-size: 0;
+	}
+
+	.header-link span {
+		font-size: 20px;
+	}
+
+	.hero {
+		min-height: 0;
+		grid-template-columns: 1fr;
+		padding-top: 64px;
+	}
+
+	.hero h1 {
+		font-size: clamp(50px, 15.4vw, 84px);
+	}
+
+	.hero-intro {
+		margin-top: 28px;
+	}
+
+	.hero-actions {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.hero-visual {
+		min-height: 360px;
+		margin-top: 25px;
+	}
+
+	.hero-visual::before {
+		width: min(76vw, 350px);
+	}
+
+	.hero-orbit-one,
+	.hero-orbit-two {
+		width: min(88vw, 410px);
+	}
+
+	.catalog {
+		padding-top: 70px;
+	}
+
+	.catalog-heading {
+		grid-template-columns: 1fr;
+		gap: 22px;
+	}
+
+	.catalog-controls {
+		grid-template-columns: 1fr;
+	}
+
+	.sort-control {
+		min-height: 48px;
+		padding-left: 8px;
+	}
+
+	.project-dialog[open] {
+		display: block;
+	}
+
+	.project-dialog {
+		width: calc(100vw - 20px);
+		max-height: calc(100vh - 20px);
+	}
+
+	.dialog-media {
+		min-height: 0;
+		aspect-ratio: 16 / 10;
+	}
+
+	.dialog-media video {
+		max-height: none;
+	}
+
+	.dialog-content {
+		max-height: none;
+		padding: 32px 22px 24px;
+	}
+
+	.dialog-close {
+		position: fixed;
+		top: 17px;
+		right: 17px;
+	}
+}
+
+@media (max-width: 560px) {
+	.project-grid {
+		grid-template-columns: 1fr;
+		row-gap: 36px;
+	}
+
+	.card-title {
+		font-size: 25px;
+	}
+
+	.search-control kbd {
+		display: none;
+	}
+
+	.site-footer {
+		align-items: flex-start;
+		flex-direction: column;
+		justify-content: center;
+	}
+
+	.dialog-actions,
+	.dialog-meta {
+		grid-template-columns: 1fr;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html {
+		scroll-behavior: auto;
+	}
+
+	.loading-state span,
+	.video-loading span {
+		animation-duration: 0.01ms;
+		animation-iteration-count: 1;
+	}
+
+	.card-image-wrap img,
+	.card-play,
+	.card-arrow {
+		transition-duration: 0.01ms;
+	}
+}
+
+[hidden] {
+	display: none;
+}


### PR DESCRIPTION
## What changed

- Added a dependency-free visual catalog for all 550 projects in the directory.
- Built the catalog from the existing `README.md`, `posters.json`, and `project-dates.json` data so it stays aligned with repository content.
- Added search across names, descriptions, and technology stacks.
- Added category filters, recent/name/category sorting, and incremental loading.
- Added a focused demo preview with links to each project's source and original prompt.
- Documented the one-command local preview workflow in the README.

## Why

The repository contains a large collection of visual experiments, but browsing it folder by folder makes discovery difficult. This adds a lightweight visual entry point that uses the posters and demo recordings already maintained by the project.

Posters and videos load on demand from the repository's GitHub media URLs, so contributors can use the explorer without downloading the full multi-gigabyte media collection.

## Local preview

```sh
python3 -m http.server 4173
```

Then open `http://127.0.0.1:4173`.

## Validation

- `npx --yes @biomejs/biome@2.3.8 lint index.html styles.css app.js`
- `node --check app.js`
- Confirmed all 550 README projects are parsed and matched by the poster manifest.
- Tested desktop and mobile layouts in the browser.
- Tested search, category filtering, sorting, pagination, demo playback, and source/prompt links.
- Confirmed there are no browser console errors or horizontal-overflow issues.
