### PR TITLE
Remove missing Carrington video source

### DIFF
--- a/templates/premium/lexingtonthemes/carrington/index.html
+++ b/templates/premium/lexingtonthemes/carrington/index.html
@@ -467,8 +467,6 @@
 							class="hero-video"
 							style="background:var(--color-base-50)"
 						>
-							<source src="assets/bgvideo2.mp4" type="video/mp4">
-							<!-- Fallback: hero image if no video -->
 						</video>
 						<!-- Fallback bg image in case video doesn't load -->
 						<div


### PR DESCRIPTION
Removes the unavailable Carrington hero video request while preserving the verified local image fallback and exact page geometry.