### PR TITLE
Fix animated dots mobile overflow

### DIFF
--- a/components-ui/animated-dots-rain/src/App.tsx
+++ b/components-ui/animated-dots-rain/src/App.tsx
@@ -543,7 +543,7 @@ export default function App() {
 					{/* step grid */}
 					<div className="mt-10 grid gap-x-10 gap-y-12 lg:grid-cols-2">
 						{/* step 0 — scaffold */}
-						<div>
+						<div className="min-w-0">
 							<StepHead
 								icon={<Terminal className="h-4 w-4" />}
 								n="0"
@@ -561,7 +561,7 @@ export default function App() {
 						</div>
 
 						{/* step 1 — dependency */}
-						<div>
+						<div className="min-w-0">
 							<StepHead
 								icon={<Package className="h-4 w-4" />}
 								n="1"
@@ -602,7 +602,7 @@ export default function App() {
 						</div>
 
 						{/* step 2 — component */}
-						<div className="lg:col-span-2">
+						<div className="min-w-0 lg:col-span-2">
 							<StepHead
 								icon={<FolderTree className="h-4 w-4" />}
 								n="2"
@@ -631,7 +631,7 @@ export default function App() {
 								</p>
 							</div>
 							<div className="grid gap-6 lg:grid-cols-2">
-								<div>
+								<div className="min-w-0">
 									<FileLabel path="src/components/ui/animated-dots.tsx" />
 									<CodeBlock
 										code={COMPONENT_SOURCE}
@@ -639,7 +639,7 @@ export default function App() {
 										className="max-h-[460px] overflow-y-auto"
 									/>
 								</div>
-								<div>
+								<div className="min-w-0">
 									<FileLabel path="src/components/ui/demo.tsx" />
 									<CodeBlock code={DEMO_SOURCE} lang="tsx" />
 									<div className="mt-4">


### PR DESCRIPTION
Constrain integration grid children so the preview remains within narrow mobile viewports.