### PR TITLE
Fix Slow Roast mobile heading wrap

### DIFF
--- a/landing-pages/slow-roast-atelier-h84/index.html
+++ b/landing-pages/slow-roast-atelier-h84/index.html
@@ -88,7 +88,7 @@
 					</div>
 					<div class="hero-grid">
 						<div class="block block-rose hero-title">
-							<h1>The Fine Art of Slow&nbsp;Roasting</h1>
+							<h1>The Fine Art of Slow Roasting</h1>
 						</div>
 						<div class="block block-cream hero-philosophy">
 							<p class="hero-lead">


### PR DESCRIPTION
Allow the Slow Roast hero title to wrap within narrow viewports.