### PR TITLE
Fix Vermillion Table mobile navigation

### DIFF
--- a/landing-pages/vermillion-table-h83/styles.css
+++ b/landing-pages/vermillion-table-h83/styles.css
@@ -231,6 +231,24 @@ a {
 	opacity: 1;
 }
 
+@media (max-width: 719px) {
+	.header {
+		padding-top: 12px;
+	}
+	.nav {
+		gap: 12px;
+		padding: 12px 14px;
+	}
+	.nav__links {
+		display: none;
+	}
+	.btn--ghost-teal {
+		height: 38px;
+		padding: 0 14px;
+		font-size: 13px;
+	}
+}
+
 /* ── shell / islands ── */
 .shell {
 	width: 100%;


### PR DESCRIPTION
Compact the Vermillion Table header on narrow viewports to eliminate horizontal overflow.