### PR TITLE
Fix Voltframe mobile menu overflow

### DIFF
--- a/landing-pages/voltframe-dev-h29/styles.css
+++ b/landing-pages/voltframe-dev-h29/styles.css
@@ -183,11 +183,17 @@ a {
 	align-items: center;
 	justify-content: center;
 	gap: 24px;
-	transform: translateX(100%);
-	transition: transform 0.3s ease-in-out;
+	opacity: 0;
+	pointer-events: none;
+	visibility: hidden;
+	transition:
+		opacity 0.3s ease-in-out,
+		visibility 0.3s ease-in-out;
 }
 .mobile-menu.open {
-	transform: translateX(0);
+	opacity: 1;
+	pointer-events: auto;
+	visibility: visible;
 }
 .mobile-menu a {
 	font-weight: 500;


### PR DESCRIPTION
Keep the closed mobile menu inside the viewport while preserving its transition and interaction states.