### PR TITLE
Fit Helix Strata wordmark across viewports

### DIFF
--- a/landing-pages/helix-strata-h76/styles.css
+++ b/landing-pages/helix-strata-h76/styles.css
@@ -724,7 +724,7 @@ header.nav {
 	padding: 80px 0 96px;
 }
 .giant span {
-	font-size: clamp(72px, 18vw, 200px);
+	font-size: clamp(36px, 14vw, 160px);
 	font-weight: 700;
 	letter-spacing: -0.04em;
 	color: var(--white);


### PR DESCRIPTION
Scale the oversized closing wordmark within every supported viewport without changing its visual treatment.