### PR TITLE
Clip Crimson Cut marquee overflow

### DIFF
--- a/landing-pages/crimson-cut-studio-h72/styles.css
+++ b/landing-pages/crimson-cut-studio-h72/styles.css
@@ -32,6 +32,7 @@
 html {
 	scroll-behavior: smooth;
 	-webkit-text-size-adjust: 100%;
+	overflow-x: clip;
 }
 
 body {


### PR DESCRIPTION
Contain the animated testimonial marquee at the document boundary across responsive viewports.