### PR TITLE
Fix Spline React runtime bundling

### DIFF
--- a/components-ui/interactive-3d-spline-scene/vite.config.ts
+++ b/components-ui/interactive-3d-spline-scene/vite.config.ts
@@ -11,15 +11,4 @@ export default defineConfig({
 		},
 	},
 	plugins: [react()],
-	build: {
-		rollupOptions: {
-			output: {
-				manualChunks: {
-					react: ["react", "react-dom"],
-					motion: ["framer-motion"],
-					spline: ["@splinetool/react-spline", "@splinetool/runtime"],
-				},
-			},
-		},
-	},
 });


### PR DESCRIPTION
Removes the circular manual chunk split so the Spline scene shares one initialized React runtime.