### PR TITLE
ci: use Pukbot for Pages setup

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,6 +28,7 @@ jobs:
           private-key: ${{ secrets.PUKBOT_PRIVATE_KEY }}
           owner: pulkitxm
           repositories: claude-directory
+          permission-actions: read
           permission-pages: write
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -39,6 +40,8 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Test asset versioning
         run: node --test scripts/version-pages-assets.test.mjs
       - name: Build previews


### PR DESCRIPTION
Pass scoped Pukbot credentials through both Pages configuration and deployment.